### PR TITLE
Feature/grpc client connection config

### DIFF
--- a/lib/go/common/baseGrpcClient.go
+++ b/lib/go/common/baseGrpcClient.go
@@ -68,9 +68,17 @@ func NewBaseGRPCClient[T any](
 	}
 
 	// Create gRPC connection
-	conn, err := createConnection(config)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create gRPC connection: %w", err)
+	var (
+		conn *grpc.ClientConn
+		err  error
+	)
+	if config.ClientConnection == nil {
+		conn, err = createConnection(config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gRPC connection: %w", err)
+		}
+	} else {
+		conn = config.ClientConnection
 	}
 
 	// Create typed gRPC client

--- a/lib/go/common/serviceConfig.go
+++ b/lib/go/common/serviceConfig.go
@@ -17,6 +17,7 @@ type ServiceConfig struct {
 	APIKey            string
 	CredentialsFile   string
 	UnaryInterceptors []grpc.UnaryClientInterceptor
+	ClientConnection  *grpc.ClientConn
 }
 
 // ServiceOption is a functional option for configuring a gRPC service client
@@ -145,5 +146,12 @@ func WithDevelopmentDefaults() ServiceOption {
 		c.TLS = false
 		c.Timeout = 10 * time.Second
 		c.URL = "localhost:9090"
+	}
+}
+
+// WithConnection congfigures the client to use the given grpc client connection instead of constructing one
+func WithConnection(grpcClientConnection *grpc.ClientConn) ServiceOption {
+	return func(c *ServiceConfig) {
+		c.ClientConnection = grpcClientConnection
 	}
 }


### PR DESCRIPTION
Added support for reusing a pre-configured gRPC client connection across multiple service clients, enabling connection pooling and reducing overhead when instantiating multiple services.                                               
                                                                                                                                                                                                                                           
  Changes                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                           
  lib/go/common/serviceConfig.go                                                                                                                                                                                                           
                                                                                                                                                                                                                                           
  - Added ClientConnection field to ServiceConfig to hold an optional pre-configured gRPC connection                                                                                                                                       
  - Added WithConnection() functional option to configure clients with an existing *grpc.ClientConn                                                                                                                                        
                                                                                                                                                                                                                                           
  lib/go/common/baseGrpcClient.go                                                                                                                                                                                                          
                                                                                                                                                                                                                                           
  - Modified connection initialization logic to check if a ClientConnection is provided in the config                                                                                                                                      
  - If provided, uses the supplied connection instead of creating a new one                                                                                                                                                                
  - Falls back to creating a new connection via createConnection() if no connection is provided                                                                                                                                            