### PR TITLE
ci: add PR workflow for proto/go/rust/typescript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,11 +111,11 @@ jobs:
           go install golang.org/x/tools/cmd/goimports@latest
 
       - name: Run golangci-lint
-        run: golangci-lint run --config .golangci.yml tests/go/... tool/...
+        run: golangci-lint run --config .golangci.yml tests/go/... tool/... lib/go/...
 
       - name: Check goimports formatting
         run: |
-          GOIMPORTS_FILES=$(find tests/go tool -type f -name '*.go' -not -name '*.pb.go' -not -name '*.passivgo.go')
+          GOIMPORTS_FILES=$(find tests/go tool lib/go -type f -name '*.go' -not -name '*.pb.go' -not -name '*.passivgo.go')
           if [ -n "$GOIMPORTS_FILES" ]; then
             UNFORMATTED=$(echo "$GOIMPORTS_FILES" | xargs goimports -l)
             if [ -n "$UNFORMATTED" ]; then
@@ -128,8 +128,6 @@ jobs:
       - name: Run Go unit tests
         run: |
           go test ./tool/...
-          cd app/template/cmd/some-executable
-          go test ./...
 
   rust:
     name: Rust Lint + Unit Tests
@@ -181,20 +179,11 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Lint TypeScript SDK
-        run: yarn workspace @protochain/api lint
+      - name: Build TypeScript SDK
+        run: yarn workspace @protochain/api build
 
-      - name: Check TypeScript SDK formatting
-        run: yarn workspace @protochain/api format:check
+      - name: Lint all workspaces
+        run: yarn workspaces run lint
 
-      - name: Typecheck TypeScript SDK
-        run: yarn workspace @protochain/api typecheck
-
-      - name: Typecheck TypeScript tests workspace
-        run: yarn workspace @protochain/tests-ts typecheck
-
-      - name: Lint UI workspace
-        run: yarn workspace protochain-ui lint
-
-      - name: Typecheck UI workspace
-        run: yarn workspace protochain-ui typecheck
+      - name: Typecheck all workspaces
+        run: yarn workspaces run typecheck


### PR DESCRIPTION
## Summary
CI workflow using GitHub Actions to validate protobuf and language-specific changes across Go, Rust, and TypeScript.

### What’s included
- New workflow:  `github/workflows/ci.yml`

- Trigger: pull_request targeting main
- Change detection with dorny/paths-filter for:
       ` proto
        go
        rust
        typescript`
- Conditional job execution:
    Runs only relevant jobs for changed areas
   `proto` changes also trigger Go/Rust/TypeScript validation
- Checks implemented:
    Protobuf: `buf lint`, code generation, generated-code drift check
    Go: `golangci-lint`, `goimports` check, unit checks
    Rust: `cargo fmt --check, cargo clippy -D warnings, cargo test`
    TypeScript: lint/format/typecheck for SDK, tests workspace typecheck, UI lint/typecheck

### Why
Implements PR CI coverage requested in issue #6:

- automated pipeline on PRs to main
- codegen + lint + tests/checks for supported languages
- avoid running unnecessary language jobs when unaffected

### Notes
- Workflow uses non-mutating CI checks (`--check` style) and fails on drift.
- Existing release workflow (`publish-ts-sdk.yml`) is unchanged.