### PR TITLE
Add burn instruction

### DIFF
--- a/app/protochain/cmd/solana-dashboard/method-page-status-tracker.md
+++ b/app/protochain/cmd/solana-dashboard/method-page-status-tracker.md
@@ -10,3 +10,5 @@ All method pages that are not yet implemented MUST show an "Under Construction" 
 | Account V1 | GetAccount | `/account-v1/get-account` | Complete |
 | Account V1 | FundNative | `/account-v1/fund-native` | Complete |
 | Program > Token V1 | ParseMint | `/program/token-v1/parse-mint` | Complete |
+| Program > Token V1 | CreateToken2022Mint | `/program/token-v1/create-token-2022-mint` | Complete |
+| Program > Token V1 | Mint | `/program/token-v1/mint` | Complete |

--- a/app/protochain/cmd/solana-dashboard/src/app/program/token-v1/create-token-2022-mint/page.tsx
+++ b/app/protochain/cmd/solana-dashboard/src/app/program/token-v1/create-token-2022-mint/page.tsx
@@ -1,5 +1,658 @@
-import { UnderConstruction } from "@/components/under-construction";
+"use client";
 
-export default function Page() {
-  return <UnderConstruction methodName="Create Token 2022 Mint" />;
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useProtochain } from "@/providers/protochain-provider";
+import { RequestForm } from "@/components/method/request-form";
+import { ResponsePanel } from "@/components/method/response-panel";
+import { FieldInput } from "@/components/method/field-input";
+import { FieldSelect } from "@/components/method/field-select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Plus, X } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Extension-specific sub-forms
+// ---------------------------------------------------------------------------
+
+type ExtensionKind =
+  | "metadata"
+  | "mintCloseAuthority"
+  | "transferFee"
+  | "defaultAccountState"
+  | "permanentDelegate"
+  | "pausable";
+
+const EXTENSION_OPTIONS: { label: string; value: ExtensionKind }[] = [
+  { label: "Metadata", value: "metadata" },
+  { label: "Mint Close Authority", value: "mintCloseAuthority" },
+  { label: "Transfer Fee", value: "transferFee" },
+  { label: "Default Account State", value: "defaultAccountState" },
+  { label: "Permanent Delegate", value: "permanentDelegate" },
+  { label: "Pausable", value: "pausable" },
+];
+
+// State shapes for each extension kind
+interface MetadataState {
+  metadataAddress: string;
+  updateAuthorityPubKey: string;
+  name: string;
+  symbol: string;
+  uri: string;
+  additionalMetadata: { key: string; value: string }[];
+}
+
+interface MintCloseAuthorityState {
+  closeAuthorityPubKey: string;
+}
+
+interface TransferFeeState {
+  transferFeeConfigAuthorityPubKey: string;
+  withdrawWithheldAuthorityPubKey: string;
+  transferFeeBasisPoints: string;
+  maximumFee: string;
+}
+
+interface DefaultAccountStateState {
+  state: string; // enum value as string
+}
+
+interface PermanentDelegateState {
+  delegatePubKey: string;
+}
+
+interface PausableState {
+  authorityPubKey: string;
+}
+
+type ExtensionState =
+  | { kind: "metadata"; data: MetadataState }
+  | { kind: "mintCloseAuthority"; data: MintCloseAuthorityState }
+  | { kind: "transferFee"; data: TransferFeeState }
+  | { kind: "defaultAccountState"; data: DefaultAccountStateState }
+  | { kind: "permanentDelegate"; data: PermanentDelegateState }
+  | { kind: "pausable"; data: PausableState };
+
+function makeDefaultExtension(kind: ExtensionKind): ExtensionState {
+  switch (kind) {
+    case "metadata":
+      return {
+        kind,
+        data: {
+          metadataAddress: "",
+          updateAuthorityPubKey: "",
+          name: "",
+          symbol: "",
+          uri: "",
+          additionalMetadata: [],
+        },
+      };
+    case "mintCloseAuthority":
+      return { kind, data: { closeAuthorityPubKey: "" } };
+    case "transferFee":
+      return {
+        kind,
+        data: {
+          transferFeeConfigAuthorityPubKey: "",
+          withdrawWithheldAuthorityPubKey: "",
+          transferFeeBasisPoints: "0",
+          maximumFee: "0",
+        },
+      };
+    case "defaultAccountState":
+      return { kind, data: { state: "1" } };
+    case "permanentDelegate":
+      return { kind, data: { delegatePubKey: "" } };
+    case "pausable":
+      return { kind, data: { authorityPubKey: "" } };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Extension sub-form components
+// ---------------------------------------------------------------------------
+
+function MetadataForm({
+  data,
+  onChange,
+}: {
+  data: MetadataState;
+  onChange: (d: MetadataState) => void;
+}) {
+  function addKV() {
+    onChange({
+      ...data,
+      additionalMetadata: [...data.additionalMetadata, { key: "", value: "" }],
+    });
+  }
+  function removeKV(idx: number) {
+    onChange({
+      ...data,
+      additionalMetadata: data.additionalMetadata.filter((_, i) => i !== idx),
+    });
+  }
+  function updateKV(idx: number, field: "key" | "value", val: string) {
+    const updated = [...data.additionalMetadata];
+    updated[idx] = { ...updated[idx], [field]: val };
+    onChange({ ...data, additionalMetadata: updated });
+  }
+
+  return (
+    <div className="space-y-3">
+      <FieldInput
+        label="Name"
+        value={data.name}
+        onChange={(v) => onChange({ ...data, name: v })}
+        placeholder='e.g. "My Token"'
+        required
+      />
+      <FieldInput
+        label="Symbol"
+        value={data.symbol}
+        onChange={(v) => onChange({ ...data, symbol: v })}
+        placeholder='e.g. "MYTKN"'
+        required
+      />
+      <FieldInput
+        label="URI"
+        value={data.uri}
+        onChange={(v) => onChange({ ...data, uri: v })}
+        placeholder="https://... or ipfs://..."
+        description="Off-chain metadata JSON URL"
+      />
+      <FieldInput
+        label="Metadata Address"
+        value={data.metadataAddress}
+        onChange={(v) => onChange({ ...data, metadataAddress: v })}
+        placeholder="Leave empty to default to mint address"
+        description="Defaults to the mint public key if empty"
+      />
+      <FieldInput
+        label="Update Authority"
+        value={data.updateAuthorityPubKey}
+        onChange={(v) => onChange({ ...data, updateAuthorityPubKey: v })}
+        placeholder="Leave empty to default to mint authority"
+        description="Defaults to the mint authority if empty"
+      />
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium">Additional Metadata</p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addKV}
+          >
+            <Plus className="mr-1 h-3 w-3" />
+            Add Field
+          </Button>
+        </div>
+        {data.additionalMetadata.map((kv, idx) => (
+          <div key={idx} className="flex items-center gap-2">
+            <FieldInput
+              label=""
+              value={kv.key}
+              onChange={(v) => updateKV(idx, "key", v)}
+              placeholder="Key"
+            />
+            <FieldInput
+              label=""
+              value={kv.value}
+              onChange={(v) => updateKV(idx, "value", v)}
+              placeholder="Value"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="shrink-0"
+              onClick={() => removeKV(idx)}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function MintCloseAuthorityForm({
+  data,
+  onChange,
+}: {
+  data: MintCloseAuthorityState;
+  onChange: (d: MintCloseAuthorityState) => void;
+}) {
+  return (
+    <FieldInput
+      label="Close Authority"
+      value={data.closeAuthorityPubKey}
+      onChange={(v) => onChange({ closeAuthorityPubKey: v })}
+      placeholder="Leave empty to default to mint authority"
+      description="Authority that may close the mint account"
+    />
+  );
+}
+
+function TransferFeeForm({
+  data,
+  onChange,
+}: {
+  data: TransferFeeState;
+  onChange: (d: TransferFeeState) => void;
+}) {
+  return (
+    <div className="space-y-3">
+      <FieldInput
+        label="Transfer Fee Config Authority"
+        value={data.transferFeeConfigAuthorityPubKey}
+        onChange={(v) =>
+          onChange({ ...data, transferFeeConfigAuthorityPubKey: v })
+        }
+        placeholder="Leave empty for immutable fee"
+        description="Authority that can modify the transfer fee"
+      />
+      <FieldInput
+        label="Withdraw Withheld Authority"
+        value={data.withdrawWithheldAuthorityPubKey}
+        onChange={(v) =>
+          onChange({ ...data, withdrawWithheldAuthorityPubKey: v })
+        }
+        placeholder="Leave empty for no withdraw authority"
+        description="Authority that can withdraw withheld fees"
+      />
+      <FieldInput
+        label="Transfer Fee (basis points)"
+        value={data.transferFeeBasisPoints}
+        onChange={(v) => onChange({ ...data, transferFeeBasisPoints: v })}
+        placeholder="100 = 1%"
+        description="Fee in basis points (100 = 1%, max 10000)"
+      />
+      <FieldInput
+        label="Maximum Fee"
+        value={data.maximumFee}
+        onChange={(v) => onChange({ ...data, maximumFee: v })}
+        placeholder="0 for no maximum"
+        description="Maximum fee per transfer in base token units"
+      />
+    </div>
+  );
+}
+
+function DefaultAccountStateForm({
+  data,
+  onChange,
+}: {
+  data: DefaultAccountStateState;
+  onChange: (d: DefaultAccountStateState) => void;
+}) {
+  return (
+    <FieldSelect
+      label="Default Account State"
+      value={data.state}
+      onChange={(v) => onChange({ state: v })}
+      options={[
+        { label: "Initialized", value: "1" },
+        { label: "Frozen", value: "2" },
+      ]}
+      description="Default state for new token accounts"
+    />
+  );
+}
+
+function PermanentDelegateForm({
+  data,
+  onChange,
+}: {
+  data: PermanentDelegateState;
+  onChange: (d: PermanentDelegateState) => void;
+}) {
+  return (
+    <FieldInput
+      label="Delegate Public Key"
+      value={data.delegatePubKey}
+      onChange={(v) => onChange({ delegatePubKey: v })}
+      placeholder="Base58-encoded public key"
+      description="Irrevocable delegate authority over all token accounts"
+      required
+    />
+  );
+}
+
+function PausableForm({
+  data,
+  onChange,
+}: {
+  data: PausableState;
+  onChange: (d: PausableState) => void;
+}) {
+  return (
+    <FieldInput
+      label="Pause Authority"
+      value={data.authorityPubKey}
+      onChange={(v) => onChange({ authorityPubKey: v })}
+      placeholder="Leave empty to default to mint authority"
+      description="Authority that can pause and resume mint activity"
+    />
+  );
+}
+
+function ExtensionSubForm({
+  ext,
+  onChange,
+}: {
+  ext: ExtensionState;
+  onChange: (e: ExtensionState) => void;
+}) {
+  switch (ext.kind) {
+    case "metadata":
+      return (
+        <MetadataForm
+          data={ext.data}
+          onChange={(d) => onChange({ kind: "metadata", data: d })}
+        />
+      );
+    case "mintCloseAuthority":
+      return (
+        <MintCloseAuthorityForm
+          data={ext.data}
+          onChange={(d) => onChange({ kind: "mintCloseAuthority", data: d })}
+        />
+      );
+    case "transferFee":
+      return (
+        <TransferFeeForm
+          data={ext.data}
+          onChange={(d) => onChange({ kind: "transferFee", data: d })}
+        />
+      );
+    case "defaultAccountState":
+      return (
+        <DefaultAccountStateForm
+          data={ext.data}
+          onChange={(d) => onChange({ kind: "defaultAccountState", data: d })}
+        />
+      );
+    case "permanentDelegate":
+      return (
+        <PermanentDelegateForm
+          data={ext.data}
+          onChange={(d) => onChange({ kind: "permanentDelegate", data: d })}
+        />
+      );
+    case "pausable":
+      return (
+        <PausableForm
+          data={ext.data}
+          onChange={(d) => onChange({ kind: "pausable", data: d })}
+        />
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Serialise extension state → proto-compatible object
+// ---------------------------------------------------------------------------
+
+function extensionToProto(ext: ExtensionState): Record<string, unknown> {
+  switch (ext.kind) {
+    case "metadata": {
+      const additionalMetadata: Record<string, string> = {};
+      for (const kv of ext.data.additionalMetadata) {
+        if (kv.key.trim()) additionalMetadata[kv.key] = kv.value;
+      }
+      return {
+        extension: {
+          case: "metadata",
+          value: {
+            metadataAddress: ext.data.metadataAddress,
+            updateAuthorityPubKey: ext.data.updateAuthorityPubKey,
+            name: ext.data.name,
+            symbol: ext.data.symbol,
+            uri: ext.data.uri,
+            additionalMetadata,
+          },
+        },
+      };
+    }
+    case "mintCloseAuthority":
+      return {
+        extension: {
+          case: "mintCloseAuthority",
+          value: {
+            closeAuthorityPubKey: ext.data.closeAuthorityPubKey,
+          },
+        },
+      };
+    case "transferFee":
+      return {
+        extension: {
+          case: "transferFee",
+          value: {
+            transferFeeConfigAuthorityPubKey:
+              ext.data.transferFeeConfigAuthorityPubKey,
+            withdrawWithheldAuthorityPubKey:
+              ext.data.withdrawWithheldAuthorityPubKey,
+            transferFeeBasisPoints: Number(ext.data.transferFeeBasisPoints) || 0,
+            maximumFee: BigInt(ext.data.maximumFee || "0"),
+          },
+        },
+      };
+    case "defaultAccountState":
+      return {
+        extension: {
+          case: "defaultAccountState",
+          value: {
+            state: Number(ext.data.state),
+          },
+        },
+      };
+    case "permanentDelegate":
+      return {
+        extension: {
+          case: "permanentDelegate",
+          value: {
+            delegatePubKey: ext.data.delegatePubKey,
+          },
+        },
+      };
+    case "pausable":
+      return {
+        extension: {
+          case: "pausable",
+          value: {
+            authorityPubKey: ext.data.authorityPubKey,
+          },
+        },
+      };
+  }
+}
+
+function extensionLabel(kind: ExtensionKind): string {
+  return EXTENSION_OPTIONS.find((o) => o.value === kind)?.label ?? kind;
+}
+
+// ---------------------------------------------------------------------------
+// Main form
+// ---------------------------------------------------------------------------
+
+function CreateToken2022MintForm() {
+  const searchParams = useSearchParams();
+  const { programTokenService } = useProtochain();
+
+  const [payerPubKey, setPayerPubKey] = useState(
+    searchParams.get("payer") ?? ""
+  );
+  const [mintPubKey, setMintPubKey] = useState(
+    searchParams.get("mint") ?? ""
+  );
+  const [mintAuthorityPubKey, setMintAuthorityPubKey] = useState(
+    searchParams.get("mintAuthority") ?? ""
+  );
+  const [freezeAuthorityPubKey, setFreezeAuthorityPubKey] = useState("");
+  const [decimals, setDecimals] = useState("9");
+  const [extensions, setExtensions] = useState<ExtensionState[]>([]);
+  const [extensionToAdd, setExtensionToAdd] = useState<ExtensionKind>("metadata");
+
+  const [response, setResponse] = useState<unknown>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function addExtension() {
+    setExtensions((prev) => [...prev, makeDefaultExtension(extensionToAdd)]);
+  }
+
+  function removeExtension(idx: number) {
+    setExtensions((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  function updateExtension(idx: number, ext: ExtensionState) {
+    setExtensions((prev) => prev.map((e, i) => (i === idx ? ext : e)));
+  }
+
+  async function handleSubmit() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await programTokenService.createToken2022Mint({
+        payerPubKey,
+        mintPubKey,
+        mintAuthorityPubKey,
+        freezeAuthorityPubKey,
+        decimals: Number(decimals) || 0,
+        extensions: extensions.map(extensionToProto),
+      } as Parameters<typeof programTokenService.createToken2022Mint>[0]);
+      setResponse(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <RequestForm onSubmit={handleSubmit} loading={loading}>
+        <FieldInput
+          label="Payer Public Key"
+          value={payerPubKey}
+          onChange={setPayerPubKey}
+          placeholder="Base58-encoded payer address (signer)"
+          required
+        />
+        <FieldInput
+          label="Mint Public Key"
+          value={mintPubKey}
+          onChange={setMintPubKey}
+          placeholder="Base58-encoded mint account address (signer)"
+          required
+        />
+        <FieldInput
+          label="Mint Authority"
+          value={mintAuthorityPubKey}
+          onChange={setMintAuthorityPubKey}
+          placeholder="Base58-encoded mint authority address"
+          required
+        />
+        <FieldInput
+          label="Freeze Authority"
+          value={freezeAuthorityPubKey}
+          onChange={setFreezeAuthorityPubKey}
+          placeholder="Leave empty to disable freeze"
+          description="Optional — leave empty to disable freeze functionality"
+        />
+        <FieldSelect
+          label="Decimals"
+          value={decimals}
+          onChange={setDecimals}
+          options={[
+            { label: "0 (NFT)", value: "0" },
+            { label: "6 (USDC-like)", value: "6" },
+            { label: "9 (SOL-like)", value: "9" },
+          ]}
+          description="Number of decimal places for the token"
+        />
+
+        {/* Extensions section */}
+        <Card className="border-dashed">
+          <CardHeader className="pb-3">
+            <CardTitle className="text-sm">Extensions</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {extensions.map((ext, idx) => (
+              <Card key={idx}>
+                <CardHeader className="pb-2">
+                  <div className="flex items-center justify-between">
+                    <Badge variant="secondary">{extensionLabel(ext.kind)}</Badge>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6"
+                      onClick={() => removeExtension(idx)}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <ExtensionSubForm
+                    ext={ext}
+                    onChange={(e) => updateExtension(idx, e)}
+                  />
+                </CardContent>
+              </Card>
+            ))}
+
+            <div className="flex items-end gap-2">
+              <div className="flex-1">
+                <FieldSelect
+                  label="Extension Type"
+                  value={extensionToAdd}
+                  onChange={(v) => setExtensionToAdd(v as ExtensionKind)}
+                  options={EXTENSION_OPTIONS}
+                />
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={addExtension}
+                className="mb-0.5"
+              >
+                <Plus className="mr-1 h-3 w-3" />
+                Add
+              </Button>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Extensions cannot be added after mint creation.
+            </p>
+          </CardContent>
+        </Card>
+      </RequestForm>
+
+      <ResponsePanel data={response} error={error} loading={loading} />
+    </>
+  );
+}
+
+export default function CreateToken2022MintPage() {
+  return (
+    <div className="max-w-2xl space-y-4">
+      <Suspense
+        fallback={
+          <div className="space-y-4">
+            <Skeleton className="h-[400px] w-full" />
+            <Skeleton className="h-[100px] w-full" />
+          </div>
+        }
+      >
+        <CreateToken2022MintForm />
+      </Suspense>
+    </div>
+  );
 }

--- a/app/protochain/cmd/solana-dashboard/src/app/program/token-v1/mint/page.tsx
+++ b/app/protochain/cmd/solana-dashboard/src/app/program/token-v1/mint/page.tsx
@@ -1,5 +1,93 @@
-import { UnderConstruction } from "@/components/under-construction";
+"use client";
 
-export default function Page() {
-  return <UnderConstruction methodName="Mint" />;
+import { Suspense, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { useProtochain } from "@/providers/protochain-provider";
+import { RequestForm } from "@/components/method/request-form";
+import { ResponsePanel } from "@/components/method/response-panel";
+import { FieldInput } from "@/components/method/field-input";
+import { Skeleton } from "@/components/ui/skeleton";
+
+function MintForm() {
+  const searchParams = useSearchParams();
+  const { programTokenService } = useProtochain();
+
+  const [mintPubKey, setMintPubKey] = useState(
+    searchParams.get("mint") ?? ""
+  );
+  const [destinationOwnerPubKey, setDestinationOwnerPubKey] = useState(
+    searchParams.get("owner") ?? ""
+  );
+  const [amount, setAmount] = useState(searchParams.get("amount") ?? "");
+
+  const [response, setResponse] = useState<unknown>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await programTokenService.mint({
+        mintPubKey,
+        destinationOwnerPubKey,
+        amount,
+      } as Parameters<typeof programTokenService.mint>[0]);
+      setResponse(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <RequestForm onSubmit={handleSubmit} loading={loading}>
+        <FieldInput
+          label="Mint Public Key"
+          value={mintPubKey}
+          onChange={setMintPubKey}
+          placeholder="Base58-encoded mint account address"
+          description="The token mint to mint from"
+          required
+        />
+        <FieldInput
+          label="Destination Owner Public Key"
+          value={destinationOwnerPubKey}
+          onChange={setDestinationOwnerPubKey}
+          placeholder="Base58-encoded wallet address (not the ATA)"
+          description="The system account (wallet) that owns the destination token account. The ATA is derived automatically."
+          required
+        />
+        <FieldInput
+          label="Amount"
+          value={amount}
+          onChange={setAmount}
+          placeholder='e.g. "1.5" for 1.5 tokens'
+          description='Human-readable token amount in whole-token units (e.g. "1.0", "0.5", "1000"). Converted to base units using the mint&apos;s decimals.'
+          required
+        />
+      </RequestForm>
+
+      <ResponsePanel data={response} error={error} loading={loading} />
+    </>
+  );
+}
+
+export default function MintPage() {
+  return (
+    <div className="max-w-2xl space-y-4">
+      <Suspense
+        fallback={
+          <div className="space-y-4">
+            <Skeleton className="h-[250px] w-full" />
+            <Skeleton className="h-[100px] w-full" />
+          </div>
+        }
+      >
+        <MintForm />
+      </Suspense>
+    </div>
+  );
 }

--- a/app/solana/cmd/api/src/api/program/token/v1/service_impl.rs
+++ b/app/solana/cmd/api/src/api/program/token/v1/service_impl.rs
@@ -11,6 +11,7 @@
 //! - [`close_token_account`]    — `CloseTokenAccount`
 //! - [`freeze_thaw_token_account`] — `FreezeTokenAccount`, `ThawTokenAccount`
 
+mod burn;
 mod close_token_account;
 mod create_holding_account;
 mod create_mint;
@@ -23,8 +24,8 @@ use std::sync::Arc;
 use tonic::{Request, Response, Status};
 
 use protochain_api::protochain::solana::program::token::v1::{
-    service_server::Service as TokenProgramService, CloseTokenAccountRequest,
-    CloseTokenAccountResponse, CreateSplTokenHoldingAccountRequest,
+    service_server::Service as TokenProgramService, BurnTokenRequest, BurnTokenResponse,
+    CloseTokenAccountRequest, CloseTokenAccountResponse, CreateSplTokenHoldingAccountRequest,
     CreateSplTokenHoldingAccountResponse, CreateSplTokenMintRequest, CreateSplTokenMintResponse,
     CreateToken2022HoldingAccountRequest, CreateToken2022HoldingAccountResponse,
     CreateToken2022MintRequest, CreateToken2022MintResponse, FreezeTokenAccountRequest,
@@ -123,6 +124,13 @@ impl TokenProgramService for TokenProgramServiceImpl {
         request: Request<ThawTokenAccountRequest>,
     ) -> Result<Response<ThawTokenAccountResponse>, Status> {
         self.handle_thaw_token_account(request).await
+    }
+
+    async fn burn_token(
+        &self,
+        request: Request<BurnTokenRequest>,
+    ) -> Result<Response<BurnTokenResponse>, Status> {
+        self.handle_burn_token(request).await
     }
 
     async fn close_token_account(

--- a/app/solana/cmd/api/src/api/program/token/v1/service_impl/burn.rs
+++ b/app/solana/cmd/api/src/api/program/token/v1/service_impl/burn.rs
@@ -1,0 +1,111 @@
+//! Handler implementation for `BurnToken` (`BurnChecked`).
+
+use std::str::FromStr;
+
+use tonic::{Request, Response, Status};
+
+use protochain_api::protochain::solana::program::token::v1::{BurnTokenRequest, BurnTokenResponse};
+
+use solana_commitment_config::CommitmentConfig;
+use solana_sdk::{program_pack::Pack, pubkey::Pubkey};
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use spl_token::ID as SPL_TOKEN_PROGRAM_ID;
+use spl_token_2022::{
+    extension::StateWithExtensions, instruction::burn_checked, state::Mint,
+    ID as TOKEN_2022_PROGRAM_ID,
+};
+
+use crate::api::common::solana_conversions::sdk_instruction_to_proto;
+
+use super::super::helpers::parse_human_amount;
+use super::TokenProgramServiceImpl;
+
+impl TokenProgramServiceImpl {
+    /// Creates a `BurnChecked` instruction.
+    ///
+    /// Reads the mint account on-chain to resolve the token program and
+    /// decimal precision.  The source ATA is derived from the supplied owner
+    /// public key and the mint.
+    ///
+    /// Multi-sig authorities are not yet supported.
+    pub(crate) async fn handle_burn_token(
+        &self,
+        request: Request<BurnTokenRequest>,
+    ) -> Result<Response<BurnTokenResponse>, Status> {
+        let req = request.into_inner();
+
+        // --- validate & parse inputs ----------------------------------------
+        if req.mint_pub_key.is_empty() {
+            return Err(Status::invalid_argument("mint_pub_key is required"));
+        }
+        if req.owner_pub_key.is_empty() {
+            return Err(Status::invalid_argument("owner_pub_key is required"));
+        }
+        if req.amount.is_empty() {
+            return Err(Status::invalid_argument("amount is required"));
+        }
+
+        let mint_pubkey = Pubkey::from_str(&req.mint_pub_key)
+            .map_err(|e| Status::invalid_argument(format!("Invalid mint_pub_key: {e}")))?;
+        let owner_pubkey = Pubkey::from_str(&req.owner_pub_key)
+            .map_err(|e| Status::invalid_argument(format!("Invalid owner_pub_key: {e}")))?;
+
+        // --- fetch & parse mint account on-chain ----------------------------
+        let account = self
+            .rpc_client
+            .get_account_with_commitment(&mint_pubkey, CommitmentConfig::confirmed())
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get mint account: {e}")))?
+            .value
+            .ok_or_else(|| Status::not_found("Mint account not found"))?;
+
+        if account.owner != SPL_TOKEN_PROGRAM_ID && account.owner != TOKEN_2022_PROGRAM_ID {
+            return Err(Status::invalid_argument(format!(
+                "Account owner {} is not a known token program",
+                account.owner,
+            )));
+        }
+
+        let token_program_id = account.owner;
+
+        // Unpack the mint to read decimals.
+        let mint = if token_program_id == TOKEN_2022_PROGRAM_ID {
+            StateWithExtensions::<Mint>::unpack(&account.data)
+                .map_err(|e| Status::internal(format!("Failed to parse Token-2022 mint: {e}")))?
+                .base
+        } else {
+            Mint::unpack(&account.data)
+                .map_err(|e| Status::internal(format!("Failed to parse mint account: {e}")))?
+        };
+
+        let decimals = mint.decimals;
+
+        // --- convert human-readable amount to base units --------------------
+        let amount = parse_human_amount(&req.amount, decimals)?;
+
+        // --- derive the source ATA ------------------------------------------
+        let source_ata = get_associated_token_address_with_program_id(
+            &owner_pubkey,
+            &mint_pubkey,
+            &token_program_id,
+        );
+
+        // --- build instruction ----------------------------------------------
+        let instruction = burn_checked(
+            &token_program_id,
+            &source_ata,
+            &mint_pubkey,
+            &owner_pubkey,
+            &[], // no additional signers — multi-sig not yet supported
+            amount,
+            decimals,
+        )
+        .map_err(|e| {
+            Status::invalid_argument(format!("Failed to create BurnChecked instruction: {e}"))
+        })?;
+
+        Ok(Response::new(BurnTokenResponse {
+            instruction: Some(sdk_instruction_to_proto(instruction)),
+        }))
+    }
+}

--- a/lib/go/protochain/solana/program/token/v1/service.pb.go
+++ b/lib/go/protochain/solana/program/token/v1/service.pb.go
@@ -1268,6 +1268,136 @@ func (x *CloseTokenAccountResponse) GetInstruction() *v1.SolanaInstruction {
 	return nil
 }
 
+// Request to burn tokens from a token account.
+//
+// The service retrieves the mint account on-chain to resolve the decimal
+// precision and owning token program — so callers do not need to supply
+// those values.
+//
+// NOTE: Multi-sig authorities are not yet supported.
+type BurnTokenRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Public key of the token mint to burn from (Base58).
+	MintPubKey string `protobuf:"bytes,1,opt,name=mint_pub_key,json=mintPubKey,proto3" json:"mint_pub_key,omitempty"`
+	// Public key of the **system account** (wallet) that owns the source
+	// token account.  The Associated Token Account (ATA) is derived
+	// automatically from this owner and the mint.
+	//
+	// Do NOT pass the ATA address itself — pass the owner's system account.
+	OwnerPubKey string `protobuf:"bytes,2,opt,name=owner_pub_key,json=ownerPubKey,proto3" json:"owner_pub_key,omitempty"`
+	// Human-readable token amount as a decimal string.
+	//
+	// Express the amount in whole-token units (e.g. "1.5" for one-and-a-half
+	// tokens).  The service converts this to the on-chain base-unit
+	// representation using the mint's decimal precision.
+	//
+	// Examples (assuming 6 decimals):
+	//
+	//	"1.0"     → 1 000 000 base units
+	//	"0.5"     → 500 000 base units
+	//	"1000"    → 1 000 000 000 base units
+	//	"0.000001"→ 1 base unit
+	Amount        string `protobuf:"bytes,3,opt,name=amount,proto3" json:"amount,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BurnTokenRequest) Reset() {
+	*x = BurnTokenRequest{}
+	mi := &file_protochain_solana_program_token_v1_service_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BurnTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BurnTokenRequest) ProtoMessage() {}
+
+func (x *BurnTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_protochain_solana_program_token_v1_service_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BurnTokenRequest.ProtoReflect.Descriptor instead.
+func (*BurnTokenRequest) Descriptor() ([]byte, []int) {
+	return file_protochain_solana_program_token_v1_service_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *BurnTokenRequest) GetMintPubKey() string {
+	if x != nil {
+		return x.MintPubKey
+	}
+	return ""
+}
+
+func (x *BurnTokenRequest) GetOwnerPubKey() string {
+	if x != nil {
+		return x.OwnerPubKey
+	}
+	return ""
+}
+
+func (x *BurnTokenRequest) GetAmount() string {
+	if x != nil {
+		return x.Amount
+	}
+	return ""
+}
+
+// Response containing the burn instruction.
+type BurnTokenResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Instruction   *v1.SolanaInstruction  `protobuf:"bytes,1,opt,name=instruction,proto3" json:"instruction,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BurnTokenResponse) Reset() {
+	*x = BurnTokenResponse{}
+	mi := &file_protochain_solana_program_token_v1_service_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BurnTokenResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BurnTokenResponse) ProtoMessage() {}
+
+func (x *BurnTokenResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_protochain_solana_program_token_v1_service_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BurnTokenResponse.ProtoReflect.Descriptor instead.
+func (*BurnTokenResponse) Descriptor() ([]byte, []int) {
+	return file_protochain_solana_program_token_v1_service_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *BurnTokenResponse) GetInstruction() *v1.SolanaInstruction {
+	if x != nil {
+		return x.Instruction
+	}
+	return nil
+}
+
 var File_protochain_solana_program_token_v1_service_proto protoreflect.FileDescriptor
 
 const file_protochain_solana_program_token_v1_service_proto_rawDesc = "" +
@@ -1359,8 +1489,14 @@ const file_protochain_solana_program_token_v1_service_proto_rawDesc = "" +
 	"\x13destination_pub_key\x18\x02 \x01(\tR\x11destinationPubKey\x12*\n" +
 	"\x11authority_pub_key\x18\x03 \x01(\tR\x0fauthorityPubKey\"r\n" +
 	"\x19CloseTokenAccountResponse\x12U\n" +
-	"\vinstruction\x18\x01 \x01(\v23.protochain.solana.transaction.v1.SolanaInstructionR\vinstruction2\xc1\n" +
-	"\n" +
+	"\vinstruction\x18\x01 \x01(\v23.protochain.solana.transaction.v1.SolanaInstructionR\vinstruction\"p\n" +
+	"\x10BurnTokenRequest\x12 \n" +
+	"\fmint_pub_key\x18\x01 \x01(\tR\n" +
+	"mintPubKey\x12\"\n" +
+	"\rowner_pub_key\x18\x02 \x01(\tR\vownerPubKey\x12\x16\n" +
+	"\x06amount\x18\x03 \x01(\tR\x06amount\"j\n" +
+	"\x11BurnTokenResponse\x12U\n" +
+	"\vinstruction\x18\x01 \x01(\v23.protochain.solana.transaction.v1.SolanaInstructionR\vinstruction2\xbb\v\n" +
 	"\aService\x12\x96\x01\n" +
 	"\x13CreateToken2022Mint\x12>.protochain.solana.program.token.v1.CreateToken2022MintRequest\x1a?.protochain.solana.program.token.v1.CreateToken2022MintResponse\x12\x93\x01\n" +
 	"\x12CreateSPLTokenMint\x12=.protochain.solana.program.token.v1.CreateSPLTokenMintRequest\x1a>.protochain.solana.program.token.v1.CreateSPLTokenMintResponse\x12x\n" +
@@ -1369,7 +1505,8 @@ const file_protochain_solana_program_token_v1_service_proto_rawDesc = "" +
 	"\x1cCreateSPLTokenHoldingAccount\x12G.protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountRequest\x1aH.protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountResponse\x12i\n" +
 	"\x04Mint\x12/.protochain.solana.program.token.v1.MintRequest\x1a0.protochain.solana.program.token.v1.MintResponse\x12\x93\x01\n" +
 	"\x12FreezeTokenAccount\x12=.protochain.solana.program.token.v1.FreezeTokenAccountRequest\x1a>.protochain.solana.program.token.v1.FreezeTokenAccountResponse\x12\x8d\x01\n" +
-	"\x10ThawTokenAccount\x12;.protochain.solana.program.token.v1.ThawTokenAccountRequest\x1a<.protochain.solana.program.token.v1.ThawTokenAccountResponse\x12\x90\x01\n" +
+	"\x10ThawTokenAccount\x12;.protochain.solana.program.token.v1.ThawTokenAccountRequest\x1a<.protochain.solana.program.token.v1.ThawTokenAccountResponse\x12x\n" +
+	"\tBurnToken\x124.protochain.solana.program.token.v1.BurnTokenRequest\x1a5.protochain.solana.program.token.v1.BurnTokenResponse\x12\x90\x01\n" +
 	"\x11CloseTokenAccount\x12<.protochain.solana.program.token.v1.CloseTokenAccountRequest\x1a=.protochain.solana.program.token.v1.CloseTokenAccountResponseBTZRgithub.com/meshtrade/protochain/lib/go/protochain/solana/program/token/v1;token_v1b\x06proto3"
 
 var (
@@ -1384,7 +1521,7 @@ func file_protochain_solana_program_token_v1_service_proto_rawDescGZIP() []byte 
 	return file_protochain_solana_program_token_v1_service_proto_rawDescData
 }
 
-var file_protochain_solana_program_token_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_protochain_solana_program_token_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_protochain_solana_program_token_v1_service_proto_goTypes = []any{
 	(*CreateToken2022MintRequest)(nil),            // 0: protochain.solana.program.token.v1.CreateToken2022MintRequest
 	(*CreateToken2022MintResponse)(nil),           // 1: protochain.solana.program.token.v1.CreateToken2022MintResponse
@@ -1405,51 +1542,56 @@ var file_protochain_solana_program_token_v1_service_proto_goTypes = []any{
 	(*ThawTokenAccountResponse)(nil),              // 16: protochain.solana.program.token.v1.ThawTokenAccountResponse
 	(*CloseTokenAccountRequest)(nil),              // 17: protochain.solana.program.token.v1.CloseTokenAccountRequest
 	(*CloseTokenAccountResponse)(nil),             // 18: protochain.solana.program.token.v1.CloseTokenAccountResponse
-	(*Token2022Extension)(nil),                    // 19: protochain.solana.program.token.v1.Token2022Extension
-	(*v1.SolanaInstruction)(nil),                  // 20: protochain.solana.transaction.v1.SolanaInstruction
-	(*MetaplexTokenMetadata)(nil),                 // 21: protochain.solana.program.token.v1.MetaplexTokenMetadata
-	(TokenProgram)(0),                             // 22: protochain.solana.program.token.v1.TokenProgram
-	(*Token2022HoldingAccountExtension)(nil),      // 23: protochain.solana.program.token.v1.Token2022HoldingAccountExtension
+	(*BurnTokenRequest)(nil),                      // 19: protochain.solana.program.token.v1.BurnTokenRequest
+	(*BurnTokenResponse)(nil),                     // 20: protochain.solana.program.token.v1.BurnTokenResponse
+	(*Token2022Extension)(nil),                    // 21: protochain.solana.program.token.v1.Token2022Extension
+	(*v1.SolanaInstruction)(nil),                  // 22: protochain.solana.transaction.v1.SolanaInstruction
+	(*MetaplexTokenMetadata)(nil),                 // 23: protochain.solana.program.token.v1.MetaplexTokenMetadata
+	(TokenProgram)(0),                             // 24: protochain.solana.program.token.v1.TokenProgram
+	(*Token2022HoldingAccountExtension)(nil),      // 25: protochain.solana.program.token.v1.Token2022HoldingAccountExtension
 }
 var file_protochain_solana_program_token_v1_service_proto_depIdxs = []int32{
-	19, // 0: protochain.solana.program.token.v1.CreateToken2022MintRequest.extensions:type_name -> protochain.solana.program.token.v1.Token2022Extension
-	20, // 1: protochain.solana.program.token.v1.CreateToken2022MintResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	21, // 2: protochain.solana.program.token.v1.CreateSPLTokenMintRequest.metadata:type_name -> protochain.solana.program.token.v1.MetaplexTokenMetadata
-	20, // 3: protochain.solana.program.token.v1.CreateSPLTokenMintResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	21, // 0: protochain.solana.program.token.v1.CreateToken2022MintRequest.extensions:type_name -> protochain.solana.program.token.v1.Token2022Extension
+	22, // 1: protochain.solana.program.token.v1.CreateToken2022MintResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	23, // 2: protochain.solana.program.token.v1.CreateSPLTokenMintRequest.metadata:type_name -> protochain.solana.program.token.v1.MetaplexTokenMetadata
+	22, // 3: protochain.solana.program.token.v1.CreateSPLTokenMintResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
 	6,  // 4: protochain.solana.program.token.v1.ParseMintResponse.mint:type_name -> protochain.solana.program.token.v1.MintInfo
-	22, // 5: protochain.solana.program.token.v1.ParseMintResponse.token_program:type_name -> protochain.solana.program.token.v1.TokenProgram
-	19, // 6: protochain.solana.program.token.v1.ParseMintResponse.extensions:type_name -> protochain.solana.program.token.v1.Token2022Extension
-	21, // 7: protochain.solana.program.token.v1.ParseMintResponse.metaplex_metadata:type_name -> protochain.solana.program.token.v1.MetaplexTokenMetadata
-	23, // 8: protochain.solana.program.token.v1.CreateToken2022HoldingAccountRequest.extensions:type_name -> protochain.solana.program.token.v1.Token2022HoldingAccountExtension
-	20, // 9: protochain.solana.program.token.v1.CreateToken2022HoldingAccountResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	20, // 10: protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	20, // 11: protochain.solana.program.token.v1.MintResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	20, // 12: protochain.solana.program.token.v1.FreezeTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	20, // 13: protochain.solana.program.token.v1.ThawTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	20, // 14: protochain.solana.program.token.v1.CloseTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	0,  // 15: protochain.solana.program.token.v1.Service.CreateToken2022Mint:input_type -> protochain.solana.program.token.v1.CreateToken2022MintRequest
-	2,  // 16: protochain.solana.program.token.v1.Service.CreateSPLTokenMint:input_type -> protochain.solana.program.token.v1.CreateSPLTokenMintRequest
-	4,  // 17: protochain.solana.program.token.v1.Service.ParseMint:input_type -> protochain.solana.program.token.v1.ParseMintRequest
-	7,  // 18: protochain.solana.program.token.v1.Service.CreateToken2022HoldingAccount:input_type -> protochain.solana.program.token.v1.CreateToken2022HoldingAccountRequest
-	9,  // 19: protochain.solana.program.token.v1.Service.CreateSPLTokenHoldingAccount:input_type -> protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountRequest
-	11, // 20: protochain.solana.program.token.v1.Service.Mint:input_type -> protochain.solana.program.token.v1.MintRequest
-	13, // 21: protochain.solana.program.token.v1.Service.FreezeTokenAccount:input_type -> protochain.solana.program.token.v1.FreezeTokenAccountRequest
-	15, // 22: protochain.solana.program.token.v1.Service.ThawTokenAccount:input_type -> protochain.solana.program.token.v1.ThawTokenAccountRequest
-	17, // 23: protochain.solana.program.token.v1.Service.CloseTokenAccount:input_type -> protochain.solana.program.token.v1.CloseTokenAccountRequest
-	1,  // 24: protochain.solana.program.token.v1.Service.CreateToken2022Mint:output_type -> protochain.solana.program.token.v1.CreateToken2022MintResponse
-	3,  // 25: protochain.solana.program.token.v1.Service.CreateSPLTokenMint:output_type -> protochain.solana.program.token.v1.CreateSPLTokenMintResponse
-	5,  // 26: protochain.solana.program.token.v1.Service.ParseMint:output_type -> protochain.solana.program.token.v1.ParseMintResponse
-	8,  // 27: protochain.solana.program.token.v1.Service.CreateToken2022HoldingAccount:output_type -> protochain.solana.program.token.v1.CreateToken2022HoldingAccountResponse
-	10, // 28: protochain.solana.program.token.v1.Service.CreateSPLTokenHoldingAccount:output_type -> protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountResponse
-	12, // 29: protochain.solana.program.token.v1.Service.Mint:output_type -> protochain.solana.program.token.v1.MintResponse
-	14, // 30: protochain.solana.program.token.v1.Service.FreezeTokenAccount:output_type -> protochain.solana.program.token.v1.FreezeTokenAccountResponse
-	16, // 31: protochain.solana.program.token.v1.Service.ThawTokenAccount:output_type -> protochain.solana.program.token.v1.ThawTokenAccountResponse
-	18, // 32: protochain.solana.program.token.v1.Service.CloseTokenAccount:output_type -> protochain.solana.program.token.v1.CloseTokenAccountResponse
-	24, // [24:33] is the sub-list for method output_type
-	15, // [15:24] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	24, // 5: protochain.solana.program.token.v1.ParseMintResponse.token_program:type_name -> protochain.solana.program.token.v1.TokenProgram
+	21, // 6: protochain.solana.program.token.v1.ParseMintResponse.extensions:type_name -> protochain.solana.program.token.v1.Token2022Extension
+	23, // 7: protochain.solana.program.token.v1.ParseMintResponse.metaplex_metadata:type_name -> protochain.solana.program.token.v1.MetaplexTokenMetadata
+	25, // 8: protochain.solana.program.token.v1.CreateToken2022HoldingAccountRequest.extensions:type_name -> protochain.solana.program.token.v1.Token2022HoldingAccountExtension
+	22, // 9: protochain.solana.program.token.v1.CreateToken2022HoldingAccountResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	22, // 10: protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	22, // 11: protochain.solana.program.token.v1.MintResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	22, // 12: protochain.solana.program.token.v1.FreezeTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	22, // 13: protochain.solana.program.token.v1.ThawTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	22, // 14: protochain.solana.program.token.v1.CloseTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	22, // 15: protochain.solana.program.token.v1.BurnTokenResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	0,  // 16: protochain.solana.program.token.v1.Service.CreateToken2022Mint:input_type -> protochain.solana.program.token.v1.CreateToken2022MintRequest
+	2,  // 17: protochain.solana.program.token.v1.Service.CreateSPLTokenMint:input_type -> protochain.solana.program.token.v1.CreateSPLTokenMintRequest
+	4,  // 18: protochain.solana.program.token.v1.Service.ParseMint:input_type -> protochain.solana.program.token.v1.ParseMintRequest
+	7,  // 19: protochain.solana.program.token.v1.Service.CreateToken2022HoldingAccount:input_type -> protochain.solana.program.token.v1.CreateToken2022HoldingAccountRequest
+	9,  // 20: protochain.solana.program.token.v1.Service.CreateSPLTokenHoldingAccount:input_type -> protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountRequest
+	11, // 21: protochain.solana.program.token.v1.Service.Mint:input_type -> protochain.solana.program.token.v1.MintRequest
+	13, // 22: protochain.solana.program.token.v1.Service.FreezeTokenAccount:input_type -> protochain.solana.program.token.v1.FreezeTokenAccountRequest
+	15, // 23: protochain.solana.program.token.v1.Service.ThawTokenAccount:input_type -> protochain.solana.program.token.v1.ThawTokenAccountRequest
+	19, // 24: protochain.solana.program.token.v1.Service.BurnToken:input_type -> protochain.solana.program.token.v1.BurnTokenRequest
+	17, // 25: protochain.solana.program.token.v1.Service.CloseTokenAccount:input_type -> protochain.solana.program.token.v1.CloseTokenAccountRequest
+	1,  // 26: protochain.solana.program.token.v1.Service.CreateToken2022Mint:output_type -> protochain.solana.program.token.v1.CreateToken2022MintResponse
+	3,  // 27: protochain.solana.program.token.v1.Service.CreateSPLTokenMint:output_type -> protochain.solana.program.token.v1.CreateSPLTokenMintResponse
+	5,  // 28: protochain.solana.program.token.v1.Service.ParseMint:output_type -> protochain.solana.program.token.v1.ParseMintResponse
+	8,  // 29: protochain.solana.program.token.v1.Service.CreateToken2022HoldingAccount:output_type -> protochain.solana.program.token.v1.CreateToken2022HoldingAccountResponse
+	10, // 30: protochain.solana.program.token.v1.Service.CreateSPLTokenHoldingAccount:output_type -> protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountResponse
+	12, // 31: protochain.solana.program.token.v1.Service.Mint:output_type -> protochain.solana.program.token.v1.MintResponse
+	14, // 32: protochain.solana.program.token.v1.Service.FreezeTokenAccount:output_type -> protochain.solana.program.token.v1.FreezeTokenAccountResponse
+	16, // 33: protochain.solana.program.token.v1.Service.ThawTokenAccount:output_type -> protochain.solana.program.token.v1.ThawTokenAccountResponse
+	20, // 34: protochain.solana.program.token.v1.Service.BurnToken:output_type -> protochain.solana.program.token.v1.BurnTokenResponse
+	18, // 35: protochain.solana.program.token.v1.Service.CloseTokenAccount:output_type -> protochain.solana.program.token.v1.CloseTokenAccountResponse
+	26, // [26:36] is the sub-list for method output_type
+	16, // [16:26] is the sub-list for method input_type
+	16, // [16:16] is the sub-list for extension type_name
+	16, // [16:16] is the sub-list for extension extendee
+	0,  // [0:16] is the sub-list for field type_name
 }
 
 func init() { file_protochain_solana_program_token_v1_service_proto_init() }
@@ -1467,7 +1609,7 @@ func file_protochain_solana_program_token_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_protochain_solana_program_token_v1_service_proto_rawDesc), len(file_protochain_solana_program_token_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   19,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/lib/go/protochain/solana/program/token/v1/service_grpc.pb.go
+++ b/lib/go/protochain/solana/program/token/v1/service_grpc.pb.go
@@ -27,6 +27,7 @@ const (
 	Service_Mint_FullMethodName                          = "/protochain.solana.program.token.v1.Service/Mint"
 	Service_FreezeTokenAccount_FullMethodName            = "/protochain.solana.program.token.v1.Service/FreezeTokenAccount"
 	Service_ThawTokenAccount_FullMethodName              = "/protochain.solana.program.token.v1.Service/ThawTokenAccount"
+	Service_BurnToken_FullMethodName                     = "/protochain.solana.program.token.v1.Service/BurnToken"
 	Service_CloseTokenAccount_FullMethodName             = "/protochain.solana.program.token.v1.Service/CloseTokenAccount"
 )
 
@@ -118,6 +119,19 @@ type ServiceClient interface {
 	//
 	// NOTE: Multi-sig authorities are not yet supported.
 	ThawTokenAccount(ctx context.Context, in *ThawTokenAccountRequest, opts ...grpc.CallOption) (*ThawTokenAccountResponse, error)
+	// Burns tokens from a token account, permanently reducing the total supply.
+	//
+	// Token Program Agnostic — the service reads the mint account on-chain to
+	// determine the owning token program and the decimal precision.
+	//
+	// The Associated Token Account (ATA) for the source owner is derived
+	// automatically from the mint and the owner address.
+	//
+	// The returned instruction must be signed by the token account owner
+	// (or delegate, if one is set).
+	//
+	// NOTE: Multi-sig authorities are not yet supported.
+	BurnToken(ctx context.Context, in *BurnTokenRequest, opts ...grpc.CallOption) (*BurnTokenResponse, error)
 	// Closes a token account, transferring its remaining SOL rent to a
 	// destination address.
 	//
@@ -214,6 +228,16 @@ func (c *serviceClient) ThawTokenAccount(ctx context.Context, in *ThawTokenAccou
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(ThawTokenAccountResponse)
 	err := c.cc.Invoke(ctx, Service_ThawTokenAccount_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *serviceClient) BurnToken(ctx context.Context, in *BurnTokenRequest, opts ...grpc.CallOption) (*BurnTokenResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BurnTokenResponse)
+	err := c.cc.Invoke(ctx, Service_BurnToken_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -318,6 +342,19 @@ type ServiceServer interface {
 	//
 	// NOTE: Multi-sig authorities are not yet supported.
 	ThawTokenAccount(context.Context, *ThawTokenAccountRequest) (*ThawTokenAccountResponse, error)
+	// Burns tokens from a token account, permanently reducing the total supply.
+	//
+	// Token Program Agnostic — the service reads the mint account on-chain to
+	// determine the owning token program and the decimal precision.
+	//
+	// The Associated Token Account (ATA) for the source owner is derived
+	// automatically from the mint and the owner address.
+	//
+	// The returned instruction must be signed by the token account owner
+	// (or delegate, if one is set).
+	//
+	// NOTE: Multi-sig authorities are not yet supported.
+	BurnToken(context.Context, *BurnTokenRequest) (*BurnTokenResponse, error)
 	// Closes a token account, transferring its remaining SOL rent to a
 	// destination address.
 	//
@@ -363,6 +400,9 @@ func (UnimplementedServiceServer) FreezeTokenAccount(context.Context, *FreezeTok
 }
 func (UnimplementedServiceServer) ThawTokenAccount(context.Context, *ThawTokenAccountRequest) (*ThawTokenAccountResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ThawTokenAccount not implemented")
+}
+func (UnimplementedServiceServer) BurnToken(context.Context, *BurnTokenRequest) (*BurnTokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method BurnToken not implemented")
 }
 func (UnimplementedServiceServer) CloseTokenAccount(context.Context, *CloseTokenAccountRequest) (*CloseTokenAccountResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CloseTokenAccount not implemented")
@@ -532,6 +572,24 @@ func _Service_ThawTokenAccount_Handler(srv interface{}, ctx context.Context, dec
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Service_BurnToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BurnTokenRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ServiceServer).BurnToken(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Service_BurnToken_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ServiceServer).BurnToken(ctx, req.(*BurnTokenRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Service_CloseTokenAccount_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CloseTokenAccountRequest)
 	if err := dec(in); err != nil {
@@ -588,6 +646,10 @@ var Service_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ThawTokenAccount",
 			Handler:    _Service_ThawTokenAccount_Handler,
+		},
+		{
+			MethodName: "BurnToken",
+			Handler:    _Service_BurnToken_Handler,
 		},
 		{
 			MethodName: "CloseTokenAccount",

--- a/lib/go/protochain/solana/program/token/v1/service_grpc_adaptor.passivgo.go
+++ b/lib/go/protochain/solana/program/token/v1/service_grpc_adaptor.passivgo.go
@@ -181,6 +181,23 @@ func (a *ServiceGRPCAdaptor) ThawTokenAccount(ctx context.Context, request *Thaw
 	return thawTokenAccountResponse, nil
 }
 
+// BurnToken exposes the BurnToken method of the Service interface over gRPC
+func (a *ServiceGRPCAdaptor) BurnToken(ctx context.Context, request *BurnTokenRequest) (*BurnTokenResponse, error) {
+	ctx, span := a.tracer.Start(
+		ctx,
+		ServiceServiceProviderName+"GRPCAdaptor.BurnToken",
+	)
+	defer span.End()
+
+	// call the service interface implementation
+	burnTokenResponse, err := a.service.BurnToken(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return burnTokenResponse, nil
+}
+
 // CloseTokenAccount exposes the CloseTokenAccount method of the Service interface over gRPC
 func (a *ServiceGRPCAdaptor) CloseTokenAccount(ctx context.Context, request *CloseTokenAccountRequest) (*CloseTokenAccountResponse, error) {
 	ctx, span := a.tracer.Start(

--- a/lib/go/protochain/solana/program/token/v1/service_interface.passivgo.go
+++ b/lib/go/protochain/solana/program/token/v1/service_interface.passivgo.go
@@ -98,6 +98,20 @@ type ServiceInterface interface {
 	// NOTE: Multi-sig authorities are not yet supported.
 	ThawTokenAccount(ctx context.Context, request *ThawTokenAccountRequest) (*ThawTokenAccountResponse, error)
 
+	// Burns tokens from a token account, permanently reducing the total supply.
+	//
+	// Token Program Agnostic — the service reads the mint account on-chain to
+	// determine the owning token program and the decimal precision.
+	//
+	// The Associated Token Account (ATA) for the source owner is derived
+	// automatically from the mint and the owner address.
+	//
+	// The returned instruction must be signed by the token account owner
+	// (or delegate, if one is set).
+	//
+	// NOTE: Multi-sig authorities are not yet supported.
+	BurnToken(ctx context.Context, request *BurnTokenRequest) (*BurnTokenResponse, error)
+
 	// Closes a token account, transferring its remaining SOL rent to a
 	// destination address.
 	//

--- a/lib/go/protochain/solana/program/token/v1/service_service.passivgo.go
+++ b/lib/go/protochain/solana/program/token/v1/service_service.passivgo.go
@@ -172,6 +172,14 @@ func (s *serviceService) ThawTokenAccount(ctx context.Context, request *ThawToke
 	})
 }
 
+// BurnToken executes the BurnToken RPC method with automatic
+// client-side validation, timeout handling, distributed tracing, and authentication.
+func (s *serviceService) BurnToken(ctx context.Context, request *BurnTokenRequest) (*BurnTokenResponse, error) {
+	return common.Execute(s.Executor(), ctx, "BurnToken", request, func(ctx context.Context) (*BurnTokenResponse, error) {
+		return s.GrpcClient().BurnToken(ctx, request)
+	})
+}
+
 // CloseTokenAccount executes the CloseTokenAccount RPC method with automatic
 // client-side validation, timeout handling, distributed tracing, and authentication.
 func (s *serviceService) CloseTokenAccount(ctx context.Context, request *CloseTokenAccountRequest) (*CloseTokenAccountResponse, error) {

--- a/lib/proto/protochain/solana/program/token/v1/service.proto
+++ b/lib/proto/protochain/solana/program/token/v1/service.proto
@@ -102,6 +102,20 @@ service Service {
   // NOTE: Multi-sig authorities are not yet supported.
   rpc ThawTokenAccount(ThawTokenAccountRequest) returns (ThawTokenAccountResponse);
 
+  // Burns tokens from a token account, permanently reducing the total supply.
+  //
+  // Token Program Agnostic — the service reads the mint account on-chain to
+  // determine the owning token program and the decimal precision.
+  //
+  // The Associated Token Account (ATA) for the source owner is derived
+  // automatically from the mint and the owner address.
+  //
+  // The returned instruction must be signed by the token account owner
+  // (or delegate, if one is set).
+  //
+  // NOTE: Multi-sig authorities are not yet supported.
+  rpc BurnToken(BurnTokenRequest) returns (BurnTokenResponse);
+
   // Closes a token account, transferring its remaining SOL rent to a
   // destination address.
   //
@@ -377,5 +391,42 @@ message CloseTokenAccountRequest {
 
 // Response containing the close account instruction.
 message CloseTokenAccountResponse {
+  protochain.solana.transaction.v1.SolanaInstruction instruction = 1;
+}
+
+// Request to burn tokens from a token account.
+//
+// The service retrieves the mint account on-chain to resolve the decimal
+// precision and owning token program — so callers do not need to supply
+// those values.
+//
+// NOTE: Multi-sig authorities are not yet supported.
+message BurnTokenRequest {
+  // Public key of the token mint to burn from (Base58).
+  string mint_pub_key = 1;
+
+  // Public key of the **system account** (wallet) that owns the source
+  // token account.  The Associated Token Account (ATA) is derived
+  // automatically from this owner and the mint.
+  //
+  // Do NOT pass the ATA address itself — pass the owner's system account.
+  string owner_pub_key = 2;
+
+  // Human-readable token amount as a decimal string.
+  //
+  // Express the amount in whole-token units (e.g. "1.5" for one-and-a-half
+  // tokens).  The service converts this to the on-chain base-unit
+  // representation using the mint's decimal precision.
+  //
+  // Examples (assuming 6 decimals):
+  //   "1.0"     → 1 000 000 base units
+  //   "0.5"     → 500 000 base units
+  //   "1000"    → 1 000 000 000 base units
+  //   "0.000001"→ 1 base unit
+  string amount = 3;
+}
+
+// Response containing the burn instruction.
+message BurnTokenResponse {
   protochain.solana.transaction.v1.SolanaInstruction instruction = 1;
 }

--- a/lib/rust/src/protochain.solana.program.token.v1.rs
+++ b/lib/rust/src/protochain.solana.program.token.v1.rs
@@ -708,5 +708,46 @@ pub struct CloseTokenAccountResponse {
     #[prost(message, optional, tag="1")]
     pub instruction: ::core::option::Option<super::super::super::transaction::v1::SolanaInstruction>,
 }
+/// Request to burn tokens from a token account.
+///
+/// The service retrieves the mint account on-chain to resolve the decimal
+/// precision and owning token program — so callers do not need to supply
+/// those values.
+///
+/// NOTE: Multi-sig authorities are not yet supported.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BurnTokenRequest {
+    /// Public key of the token mint to burn from (Base58).
+    #[prost(string, tag="1")]
+    pub mint_pub_key: ::prost::alloc::string::String,
+    /// Public key of the **system account** (wallet) that owns the source
+    /// token account.  The Associated Token Account (ATA) is derived
+    /// automatically from this owner and the mint.
+    ///
+    /// Do NOT pass the ATA address itself — pass the owner's system account.
+    #[prost(string, tag="2")]
+    pub owner_pub_key: ::prost::alloc::string::String,
+    /// Human-readable token amount as a decimal string.
+    ///
+    /// Express the amount in whole-token units (e.g. "1.5" for one-and-a-half
+    /// tokens).  The service converts this to the on-chain base-unit
+    /// representation using the mint's decimal precision.
+    ///
+    /// Examples (assuming 6 decimals):
+    ///    "1.0"     → 1 000 000 base units
+    ///    "0.5"     → 500 000 base units
+    ///    "1000"    → 1 000 000 000 base units
+    ///    "0.000001"→ 1 base unit
+    #[prost(string, tag="3")]
+    pub amount: ::prost::alloc::string::String,
+}
+/// Response containing the burn instruction.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BurnTokenResponse {
+    #[prost(message, optional, tag="1")]
+    pub instruction: ::core::option::Option<super::super::super::transaction::v1::SolanaInstruction>,
+}
 include!("protochain.solana.program.token.v1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/lib/rust/src/protochain.solana.program.token.v1.tonic.rs
+++ b/lib/rust/src/protochain.solana.program.token.v1.tonic.rs
@@ -318,6 +318,36 @@ pub mod service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        pub async fn burn_token(
+            &mut self,
+            request: impl tonic::IntoRequest<super::BurnTokenRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::BurnTokenResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/protochain.solana.program.token.v1.Service/BurnToken",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "protochain.solana.program.token.v1.Service",
+                        "BurnToken",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn close_token_account(
             &mut self,
             request: impl tonic::IntoRequest<super::CloseTokenAccountRequest>,
@@ -408,6 +438,13 @@ pub mod service_server {
             request: tonic::Request<super::ThawTokenAccountRequest>,
         ) -> std::result::Result<
             tonic::Response<super::ThawTokenAccountResponse>,
+            tonic::Status,
+        >;
+        async fn burn_token(
+            &self,
+            request: tonic::Request<super::BurnTokenRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::BurnTokenResponse>,
             tonic::Status,
         >;
         async fn close_token_account(
@@ -849,6 +886,49 @@ pub mod service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = ThawTokenAccountSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/protochain.solana.program.token.v1.Service/BurnToken" => {
+                    #[allow(non_camel_case_types)]
+                    struct BurnTokenSvc<T: Service>(pub Arc<T>);
+                    impl<T: Service> tonic::server::UnaryService<super::BurnTokenRequest>
+                    for BurnTokenSvc<T> {
+                        type Response = super::BurnTokenResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::BurnTokenRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Service>::burn_token(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = BurnTokenSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(


### PR DESCRIPTION
Add BurnToken RPC and dashboard pages for CreateToken2022Mint & Mint                                                                                               
                                                                                                                                                                    
Adds BurnToken to the token program service — burns tokens from a holder's ATA, reducing total supply. Token-program agnostic; the service resolves the owning program and decimals on-chain. Accepts a human-readable amount string.                                                                                             
                                                                                                                                                                    
 Also implements two dashboard method pages that were previously stubs:                                                                                             
                                                                                                                                                                    
 - CreateToken2022Mint — full form with dynamic extension support (metadata, mint close authority, transfer fee, default account state, permanent delegate,         
   pausable)                                                                                                                                                        
 - Mint — form for minting tokens to a destination owner's ATA