### PR TITLE
Add token transfers

### DIFF
--- a/app/solana/cmd/api/src/api/program/token/v1/service_impl.rs
+++ b/app/solana/cmd/api/src/api/program/token/v1/service_impl.rs
@@ -8,6 +8,8 @@
 //! - [`parse_mint`]             — `ParseMint`
 //! - [`create_holding_account`] — `CreateToken2022HoldingAccount`, `CreateSPLTokenHoldingAccount`
 //! - [`mint`]                   — `Mint` (MintToChecked)
+//! - [`transfer`]               — `TransferToken` (TransferChecked)
+//! - [`burn`]                   — `BurnToken` (BurnChecked)
 //! - [`close_token_account`]    — `CloseTokenAccount`
 //! - [`freeze_thaw_token_account`] — `FreezeTokenAccount`, `ThawTokenAccount`
 
@@ -18,6 +20,7 @@ mod create_mint;
 mod freeze_thaw_token_account;
 mod mint;
 mod parse_mint;
+mod transfer;
 
 use std::sync::Arc;
 
@@ -30,7 +33,7 @@ use protochain_api::protochain::solana::program::token::v1::{
     CreateToken2022HoldingAccountRequest, CreateToken2022HoldingAccountResponse,
     CreateToken2022MintRequest, CreateToken2022MintResponse, FreezeTokenAccountRequest,
     FreezeTokenAccountResponse, MintRequest, MintResponse, ParseMintRequest, ParseMintResponse,
-    ThawTokenAccountRequest, ThawTokenAccountResponse,
+    ThawTokenAccountRequest, ThawTokenAccountResponse, TransferTokenRequest, TransferTokenResponse,
 };
 
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -131,6 +134,13 @@ impl TokenProgramService for TokenProgramServiceImpl {
         request: Request<BurnTokenRequest>,
     ) -> Result<Response<BurnTokenResponse>, Status> {
         self.handle_burn_token(request).await
+    }
+
+    async fn transfer_token(
+        &self,
+        request: Request<TransferTokenRequest>,
+    ) -> Result<Response<TransferTokenResponse>, Status> {
+        self.handle_transfer_token(request).await
     }
 
     async fn close_token_account(

--- a/app/solana/cmd/api/src/api/program/token/v1/service_impl/transfer.rs
+++ b/app/solana/cmd/api/src/api/program/token/v1/service_impl/transfer.rs
@@ -1,0 +1,126 @@
+//! Handler implementation for `TransferToken` (`TransferChecked`).
+
+use std::str::FromStr;
+
+use tonic::{Request, Response, Status};
+
+use protochain_api::protochain::solana::program::token::v1::{
+    TransferTokenRequest, TransferTokenResponse,
+};
+
+use solana_commitment_config::CommitmentConfig;
+use solana_sdk::{program_pack::Pack, pubkey::Pubkey};
+use spl_associated_token_account::get_associated_token_address_with_program_id;
+use spl_token::ID as SPL_TOKEN_PROGRAM_ID;
+use spl_token_2022::{
+    extension::StateWithExtensions, instruction::transfer_checked, state::Mint,
+    ID as TOKEN_2022_PROGRAM_ID,
+};
+
+use crate::api::common::solana_conversions::sdk_instruction_to_proto;
+
+use super::super::helpers::parse_human_amount;
+use super::TokenProgramServiceImpl;
+
+impl TokenProgramServiceImpl {
+    /// Creates a `TransferChecked` instruction.
+    ///
+    /// Reads the mint account on-chain to resolve the token program and
+    /// decimal precision. The source and destination ATAs are derived from
+    /// the supplied owner public keys and the mint.
+    ///
+    /// Multi-sig authorities are not yet supported.
+    pub(crate) async fn handle_transfer_token(
+        &self,
+        request: Request<TransferTokenRequest>,
+    ) -> Result<Response<TransferTokenResponse>, Status> {
+        let req = request.into_inner();
+
+        // --- validate & parse inputs ----------------------------------------
+        if req.mint_pub_key.is_empty() {
+            return Err(Status::invalid_argument("mint_pub_key is required"));
+        }
+        if req.source_owner_pub_key.is_empty() {
+            return Err(Status::invalid_argument("source_owner_pub_key is required"));
+        }
+        if req.destination_owner_pub_key.is_empty() {
+            return Err(Status::invalid_argument("destination_owner_pub_key is required"));
+        }
+        if req.amount.is_empty() {
+            return Err(Status::invalid_argument("amount is required"));
+        }
+
+        let mint_pubkey = Pubkey::from_str(&req.mint_pub_key)
+            .map_err(|e| Status::invalid_argument(format!("Invalid mint_pub_key: {e}")))?;
+        let source_owner_pubkey = Pubkey::from_str(&req.source_owner_pub_key)
+            .map_err(|e| Status::invalid_argument(format!("Invalid source_owner_pub_key: {e}")))?;
+        let destination_owner_pubkey =
+            Pubkey::from_str(&req.destination_owner_pub_key).map_err(|e| {
+                Status::invalid_argument(format!("Invalid destination_owner_pub_key: {e}"))
+            })?;
+
+        // --- fetch & parse mint account on-chain ----------------------------
+        let account = self
+            .rpc_client
+            .get_account_with_commitment(&mint_pubkey, CommitmentConfig::confirmed())
+            .await
+            .map_err(|e| Status::internal(format!("Failed to get mint account: {e}")))?
+            .value
+            .ok_or_else(|| Status::not_found("Mint account not found"))?;
+
+        if account.owner != SPL_TOKEN_PROGRAM_ID && account.owner != TOKEN_2022_PROGRAM_ID {
+            return Err(Status::invalid_argument(format!(
+                "Account owner {} is not a known token program",
+                account.owner,
+            )));
+        }
+
+        let token_program_id = account.owner;
+
+        // Unpack the mint to read decimals.
+        let mint = if token_program_id == TOKEN_2022_PROGRAM_ID {
+            StateWithExtensions::<Mint>::unpack(&account.data)
+                .map_err(|e| Status::internal(format!("Failed to parse Token-2022 mint: {e}")))?
+                .base
+        } else {
+            Mint::unpack(&account.data)
+                .map_err(|e| Status::internal(format!("Failed to parse mint account: {e}")))?
+        };
+
+        let decimals = mint.decimals;
+
+        // --- convert human-readable amount to base units --------------------
+        let amount = parse_human_amount(&req.amount, decimals)?;
+
+        // --- derive the source and destination ATAs -------------------------
+        let source_ata = get_associated_token_address_with_program_id(
+            &source_owner_pubkey,
+            &mint_pubkey,
+            &token_program_id,
+        );
+        let destination_ata = get_associated_token_address_with_program_id(
+            &destination_owner_pubkey,
+            &mint_pubkey,
+            &token_program_id,
+        );
+
+        // --- build instruction ----------------------------------------------
+        let instruction = transfer_checked(
+            &token_program_id,
+            &source_ata,
+            &mint_pubkey,
+            &destination_ata,
+            &source_owner_pubkey,
+            &[], // no additional signers — multi-sig not yet supported
+            amount,
+            decimals,
+        )
+        .map_err(|e| {
+            Status::invalid_argument(format!("Failed to create TransferChecked instruction: {e}"))
+        })?;
+
+        Ok(Response::new(TransferTokenResponse {
+            instruction: Some(sdk_instruction_to_proto(instruction)),
+        }))
+    }
+}

--- a/lib/go/protochain/solana/program/token/v1/service.pb.go
+++ b/lib/go/protochain/solana/program/token/v1/service.pb.go
@@ -1398,6 +1398,149 @@ func (x *BurnTokenResponse) GetInstruction() *v1.SolanaInstruction {
 	return nil
 }
 
+// Request to transfer tokens between token accounts.
+//
+// The service retrieves the mint account on-chain to resolve the decimal
+// precision and owning token program — so callers do not need to supply
+// those values.
+//
+// NOTE: Multi-sig authorities are not yet supported.
+type TransferTokenRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Public key of the token mint (Base58).
+	MintPubKey string `protobuf:"bytes,1,opt,name=mint_pub_key,json=mintPubKey,proto3" json:"mint_pub_key,omitempty"`
+	// Public key of the **system account** (wallet) that owns the source
+	// token account.  The Associated Token Account (ATA) is derived
+	// automatically from this owner and the mint.
+	//
+	// Do NOT pass the ATA address itself — pass the owner's system account.
+	SourceOwnerPubKey string `protobuf:"bytes,2,opt,name=source_owner_pub_key,json=sourceOwnerPubKey,proto3" json:"source_owner_pub_key,omitempty"`
+	// Public key of the **system account** (wallet) that owns the destination
+	// token account.  The Associated Token Account (ATA) is derived
+	// automatically from this owner and the mint.
+	//
+	// Do NOT pass the ATA address itself — pass the owner's system account.
+	DestinationOwnerPubKey string `protobuf:"bytes,3,opt,name=destination_owner_pub_key,json=destinationOwnerPubKey,proto3" json:"destination_owner_pub_key,omitempty"`
+	// Human-readable token amount as a decimal string.
+	//
+	// Express the amount in whole-token units (e.g. "1.5" for one-and-a-half
+	// tokens).  The service converts this to the on-chain base-unit
+	// representation using the mint's decimal precision.
+	//
+	// Examples (assuming 6 decimals):
+	//
+	//	"1.0"     → 1 000 000 base units
+	//	"0.5"     → 500 000 base units
+	//	"1000"    → 1 000 000 000 base units
+	//	"0.000001"→ 1 base unit
+	Amount        string `protobuf:"bytes,4,opt,name=amount,proto3" json:"amount,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransferTokenRequest) Reset() {
+	*x = TransferTokenRequest{}
+	mi := &file_protochain_solana_program_token_v1_service_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransferTokenRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransferTokenRequest) ProtoMessage() {}
+
+func (x *TransferTokenRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_protochain_solana_program_token_v1_service_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransferTokenRequest.ProtoReflect.Descriptor instead.
+func (*TransferTokenRequest) Descriptor() ([]byte, []int) {
+	return file_protochain_solana_program_token_v1_service_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *TransferTokenRequest) GetMintPubKey() string {
+	if x != nil {
+		return x.MintPubKey
+	}
+	return ""
+}
+
+func (x *TransferTokenRequest) GetSourceOwnerPubKey() string {
+	if x != nil {
+		return x.SourceOwnerPubKey
+	}
+	return ""
+}
+
+func (x *TransferTokenRequest) GetDestinationOwnerPubKey() string {
+	if x != nil {
+		return x.DestinationOwnerPubKey
+	}
+	return ""
+}
+
+func (x *TransferTokenRequest) GetAmount() string {
+	if x != nil {
+		return x.Amount
+	}
+	return ""
+}
+
+// Response containing the transfer instruction.
+type TransferTokenResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Instruction   *v1.SolanaInstruction  `protobuf:"bytes,1,opt,name=instruction,proto3" json:"instruction,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransferTokenResponse) Reset() {
+	*x = TransferTokenResponse{}
+	mi := &file_protochain_solana_program_token_v1_service_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransferTokenResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransferTokenResponse) ProtoMessage() {}
+
+func (x *TransferTokenResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_protochain_solana_program_token_v1_service_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransferTokenResponse.ProtoReflect.Descriptor instead.
+func (*TransferTokenResponse) Descriptor() ([]byte, []int) {
+	return file_protochain_solana_program_token_v1_service_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *TransferTokenResponse) GetInstruction() *v1.SolanaInstruction {
+	if x != nil {
+		return x.Instruction
+	}
+	return nil
+}
+
 var File_protochain_solana_program_token_v1_service_proto protoreflect.FileDescriptor
 
 const file_protochain_solana_program_token_v1_service_proto_rawDesc = "" +
@@ -1496,7 +1639,15 @@ const file_protochain_solana_program_token_v1_service_proto_rawDesc = "" +
 	"\rowner_pub_key\x18\x02 \x01(\tR\vownerPubKey\x12\x16\n" +
 	"\x06amount\x18\x03 \x01(\tR\x06amount\"j\n" +
 	"\x11BurnTokenResponse\x12U\n" +
-	"\vinstruction\x18\x01 \x01(\v23.protochain.solana.transaction.v1.SolanaInstructionR\vinstruction2\xbb\v\n" +
+	"\vinstruction\x18\x01 \x01(\v23.protochain.solana.transaction.v1.SolanaInstructionR\vinstruction\"\xbc\x01\n" +
+	"\x14TransferTokenRequest\x12 \n" +
+	"\fmint_pub_key\x18\x01 \x01(\tR\n" +
+	"mintPubKey\x12/\n" +
+	"\x14source_owner_pub_key\x18\x02 \x01(\tR\x11sourceOwnerPubKey\x129\n" +
+	"\x19destination_owner_pub_key\x18\x03 \x01(\tR\x16destinationOwnerPubKey\x12\x16\n" +
+	"\x06amount\x18\x04 \x01(\tR\x06amount\"n\n" +
+	"\x15TransferTokenResponse\x12U\n" +
+	"\vinstruction\x18\x01 \x01(\v23.protochain.solana.transaction.v1.SolanaInstructionR\vinstruction2\xc2\f\n" +
 	"\aService\x12\x96\x01\n" +
 	"\x13CreateToken2022Mint\x12>.protochain.solana.program.token.v1.CreateToken2022MintRequest\x1a?.protochain.solana.program.token.v1.CreateToken2022MintResponse\x12\x93\x01\n" +
 	"\x12CreateSPLTokenMint\x12=.protochain.solana.program.token.v1.CreateSPLTokenMintRequest\x1a>.protochain.solana.program.token.v1.CreateSPLTokenMintResponse\x12x\n" +
@@ -1506,7 +1657,8 @@ const file_protochain_solana_program_token_v1_service_proto_rawDesc = "" +
 	"\x04Mint\x12/.protochain.solana.program.token.v1.MintRequest\x1a0.protochain.solana.program.token.v1.MintResponse\x12\x93\x01\n" +
 	"\x12FreezeTokenAccount\x12=.protochain.solana.program.token.v1.FreezeTokenAccountRequest\x1a>.protochain.solana.program.token.v1.FreezeTokenAccountResponse\x12\x8d\x01\n" +
 	"\x10ThawTokenAccount\x12;.protochain.solana.program.token.v1.ThawTokenAccountRequest\x1a<.protochain.solana.program.token.v1.ThawTokenAccountResponse\x12x\n" +
-	"\tBurnToken\x124.protochain.solana.program.token.v1.BurnTokenRequest\x1a5.protochain.solana.program.token.v1.BurnTokenResponse\x12\x90\x01\n" +
+	"\tBurnToken\x124.protochain.solana.program.token.v1.BurnTokenRequest\x1a5.protochain.solana.program.token.v1.BurnTokenResponse\x12\x84\x01\n" +
+	"\rTransferToken\x128.protochain.solana.program.token.v1.TransferTokenRequest\x1a9.protochain.solana.program.token.v1.TransferTokenResponse\x12\x90\x01\n" +
 	"\x11CloseTokenAccount\x12<.protochain.solana.program.token.v1.CloseTokenAccountRequest\x1a=.protochain.solana.program.token.v1.CloseTokenAccountResponseBTZRgithub.com/meshtrade/protochain/lib/go/protochain/solana/program/token/v1;token_v1b\x06proto3"
 
 var (
@@ -1521,7 +1673,7 @@ func file_protochain_solana_program_token_v1_service_proto_rawDescGZIP() []byte 
 	return file_protochain_solana_program_token_v1_service_proto_rawDescData
 }
 
-var file_protochain_solana_program_token_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_protochain_solana_program_token_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
 var file_protochain_solana_program_token_v1_service_proto_goTypes = []any{
 	(*CreateToken2022MintRequest)(nil),            // 0: protochain.solana.program.token.v1.CreateToken2022MintRequest
 	(*CreateToken2022MintResponse)(nil),           // 1: protochain.solana.program.token.v1.CreateToken2022MintResponse
@@ -1544,54 +1696,59 @@ var file_protochain_solana_program_token_v1_service_proto_goTypes = []any{
 	(*CloseTokenAccountResponse)(nil),             // 18: protochain.solana.program.token.v1.CloseTokenAccountResponse
 	(*BurnTokenRequest)(nil),                      // 19: protochain.solana.program.token.v1.BurnTokenRequest
 	(*BurnTokenResponse)(nil),                     // 20: protochain.solana.program.token.v1.BurnTokenResponse
-	(*Token2022Extension)(nil),                    // 21: protochain.solana.program.token.v1.Token2022Extension
-	(*v1.SolanaInstruction)(nil),                  // 22: protochain.solana.transaction.v1.SolanaInstruction
-	(*MetaplexTokenMetadata)(nil),                 // 23: protochain.solana.program.token.v1.MetaplexTokenMetadata
-	(TokenProgram)(0),                             // 24: protochain.solana.program.token.v1.TokenProgram
-	(*Token2022HoldingAccountExtension)(nil),      // 25: protochain.solana.program.token.v1.Token2022HoldingAccountExtension
+	(*TransferTokenRequest)(nil),                  // 21: protochain.solana.program.token.v1.TransferTokenRequest
+	(*TransferTokenResponse)(nil),                 // 22: protochain.solana.program.token.v1.TransferTokenResponse
+	(*Token2022Extension)(nil),                    // 23: protochain.solana.program.token.v1.Token2022Extension
+	(*v1.SolanaInstruction)(nil),                  // 24: protochain.solana.transaction.v1.SolanaInstruction
+	(*MetaplexTokenMetadata)(nil),                 // 25: protochain.solana.program.token.v1.MetaplexTokenMetadata
+	(TokenProgram)(0),                             // 26: protochain.solana.program.token.v1.TokenProgram
+	(*Token2022HoldingAccountExtension)(nil),      // 27: protochain.solana.program.token.v1.Token2022HoldingAccountExtension
 }
 var file_protochain_solana_program_token_v1_service_proto_depIdxs = []int32{
-	21, // 0: protochain.solana.program.token.v1.CreateToken2022MintRequest.extensions:type_name -> protochain.solana.program.token.v1.Token2022Extension
-	22, // 1: protochain.solana.program.token.v1.CreateToken2022MintResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	23, // 2: protochain.solana.program.token.v1.CreateSPLTokenMintRequest.metadata:type_name -> protochain.solana.program.token.v1.MetaplexTokenMetadata
-	22, // 3: protochain.solana.program.token.v1.CreateSPLTokenMintResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	23, // 0: protochain.solana.program.token.v1.CreateToken2022MintRequest.extensions:type_name -> protochain.solana.program.token.v1.Token2022Extension
+	24, // 1: protochain.solana.program.token.v1.CreateToken2022MintResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	25, // 2: protochain.solana.program.token.v1.CreateSPLTokenMintRequest.metadata:type_name -> protochain.solana.program.token.v1.MetaplexTokenMetadata
+	24, // 3: protochain.solana.program.token.v1.CreateSPLTokenMintResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
 	6,  // 4: protochain.solana.program.token.v1.ParseMintResponse.mint:type_name -> protochain.solana.program.token.v1.MintInfo
-	24, // 5: protochain.solana.program.token.v1.ParseMintResponse.token_program:type_name -> protochain.solana.program.token.v1.TokenProgram
-	21, // 6: protochain.solana.program.token.v1.ParseMintResponse.extensions:type_name -> protochain.solana.program.token.v1.Token2022Extension
-	23, // 7: protochain.solana.program.token.v1.ParseMintResponse.metaplex_metadata:type_name -> protochain.solana.program.token.v1.MetaplexTokenMetadata
-	25, // 8: protochain.solana.program.token.v1.CreateToken2022HoldingAccountRequest.extensions:type_name -> protochain.solana.program.token.v1.Token2022HoldingAccountExtension
-	22, // 9: protochain.solana.program.token.v1.CreateToken2022HoldingAccountResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	22, // 10: protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	22, // 11: protochain.solana.program.token.v1.MintResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	22, // 12: protochain.solana.program.token.v1.FreezeTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	22, // 13: protochain.solana.program.token.v1.ThawTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	22, // 14: protochain.solana.program.token.v1.CloseTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	22, // 15: protochain.solana.program.token.v1.BurnTokenResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
-	0,  // 16: protochain.solana.program.token.v1.Service.CreateToken2022Mint:input_type -> protochain.solana.program.token.v1.CreateToken2022MintRequest
-	2,  // 17: protochain.solana.program.token.v1.Service.CreateSPLTokenMint:input_type -> protochain.solana.program.token.v1.CreateSPLTokenMintRequest
-	4,  // 18: protochain.solana.program.token.v1.Service.ParseMint:input_type -> protochain.solana.program.token.v1.ParseMintRequest
-	7,  // 19: protochain.solana.program.token.v1.Service.CreateToken2022HoldingAccount:input_type -> protochain.solana.program.token.v1.CreateToken2022HoldingAccountRequest
-	9,  // 20: protochain.solana.program.token.v1.Service.CreateSPLTokenHoldingAccount:input_type -> protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountRequest
-	11, // 21: protochain.solana.program.token.v1.Service.Mint:input_type -> protochain.solana.program.token.v1.MintRequest
-	13, // 22: protochain.solana.program.token.v1.Service.FreezeTokenAccount:input_type -> protochain.solana.program.token.v1.FreezeTokenAccountRequest
-	15, // 23: protochain.solana.program.token.v1.Service.ThawTokenAccount:input_type -> protochain.solana.program.token.v1.ThawTokenAccountRequest
-	19, // 24: protochain.solana.program.token.v1.Service.BurnToken:input_type -> protochain.solana.program.token.v1.BurnTokenRequest
-	17, // 25: protochain.solana.program.token.v1.Service.CloseTokenAccount:input_type -> protochain.solana.program.token.v1.CloseTokenAccountRequest
-	1,  // 26: protochain.solana.program.token.v1.Service.CreateToken2022Mint:output_type -> protochain.solana.program.token.v1.CreateToken2022MintResponse
-	3,  // 27: protochain.solana.program.token.v1.Service.CreateSPLTokenMint:output_type -> protochain.solana.program.token.v1.CreateSPLTokenMintResponse
-	5,  // 28: protochain.solana.program.token.v1.Service.ParseMint:output_type -> protochain.solana.program.token.v1.ParseMintResponse
-	8,  // 29: protochain.solana.program.token.v1.Service.CreateToken2022HoldingAccount:output_type -> protochain.solana.program.token.v1.CreateToken2022HoldingAccountResponse
-	10, // 30: protochain.solana.program.token.v1.Service.CreateSPLTokenHoldingAccount:output_type -> protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountResponse
-	12, // 31: protochain.solana.program.token.v1.Service.Mint:output_type -> protochain.solana.program.token.v1.MintResponse
-	14, // 32: protochain.solana.program.token.v1.Service.FreezeTokenAccount:output_type -> protochain.solana.program.token.v1.FreezeTokenAccountResponse
-	16, // 33: protochain.solana.program.token.v1.Service.ThawTokenAccount:output_type -> protochain.solana.program.token.v1.ThawTokenAccountResponse
-	20, // 34: protochain.solana.program.token.v1.Service.BurnToken:output_type -> protochain.solana.program.token.v1.BurnTokenResponse
-	18, // 35: protochain.solana.program.token.v1.Service.CloseTokenAccount:output_type -> protochain.solana.program.token.v1.CloseTokenAccountResponse
-	26, // [26:36] is the sub-list for method output_type
-	16, // [16:26] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	26, // 5: protochain.solana.program.token.v1.ParseMintResponse.token_program:type_name -> protochain.solana.program.token.v1.TokenProgram
+	23, // 6: protochain.solana.program.token.v1.ParseMintResponse.extensions:type_name -> protochain.solana.program.token.v1.Token2022Extension
+	25, // 7: protochain.solana.program.token.v1.ParseMintResponse.metaplex_metadata:type_name -> protochain.solana.program.token.v1.MetaplexTokenMetadata
+	27, // 8: protochain.solana.program.token.v1.CreateToken2022HoldingAccountRequest.extensions:type_name -> protochain.solana.program.token.v1.Token2022HoldingAccountExtension
+	24, // 9: protochain.solana.program.token.v1.CreateToken2022HoldingAccountResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	24, // 10: protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountResponse.instructions:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	24, // 11: protochain.solana.program.token.v1.MintResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	24, // 12: protochain.solana.program.token.v1.FreezeTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	24, // 13: protochain.solana.program.token.v1.ThawTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	24, // 14: protochain.solana.program.token.v1.CloseTokenAccountResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	24, // 15: protochain.solana.program.token.v1.BurnTokenResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	24, // 16: protochain.solana.program.token.v1.TransferTokenResponse.instruction:type_name -> protochain.solana.transaction.v1.SolanaInstruction
+	0,  // 17: protochain.solana.program.token.v1.Service.CreateToken2022Mint:input_type -> protochain.solana.program.token.v1.CreateToken2022MintRequest
+	2,  // 18: protochain.solana.program.token.v1.Service.CreateSPLTokenMint:input_type -> protochain.solana.program.token.v1.CreateSPLTokenMintRequest
+	4,  // 19: protochain.solana.program.token.v1.Service.ParseMint:input_type -> protochain.solana.program.token.v1.ParseMintRequest
+	7,  // 20: protochain.solana.program.token.v1.Service.CreateToken2022HoldingAccount:input_type -> protochain.solana.program.token.v1.CreateToken2022HoldingAccountRequest
+	9,  // 21: protochain.solana.program.token.v1.Service.CreateSPLTokenHoldingAccount:input_type -> protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountRequest
+	11, // 22: protochain.solana.program.token.v1.Service.Mint:input_type -> protochain.solana.program.token.v1.MintRequest
+	13, // 23: protochain.solana.program.token.v1.Service.FreezeTokenAccount:input_type -> protochain.solana.program.token.v1.FreezeTokenAccountRequest
+	15, // 24: protochain.solana.program.token.v1.Service.ThawTokenAccount:input_type -> protochain.solana.program.token.v1.ThawTokenAccountRequest
+	19, // 25: protochain.solana.program.token.v1.Service.BurnToken:input_type -> protochain.solana.program.token.v1.BurnTokenRequest
+	21, // 26: protochain.solana.program.token.v1.Service.TransferToken:input_type -> protochain.solana.program.token.v1.TransferTokenRequest
+	17, // 27: protochain.solana.program.token.v1.Service.CloseTokenAccount:input_type -> protochain.solana.program.token.v1.CloseTokenAccountRequest
+	1,  // 28: protochain.solana.program.token.v1.Service.CreateToken2022Mint:output_type -> protochain.solana.program.token.v1.CreateToken2022MintResponse
+	3,  // 29: protochain.solana.program.token.v1.Service.CreateSPLTokenMint:output_type -> protochain.solana.program.token.v1.CreateSPLTokenMintResponse
+	5,  // 30: protochain.solana.program.token.v1.Service.ParseMint:output_type -> protochain.solana.program.token.v1.ParseMintResponse
+	8,  // 31: protochain.solana.program.token.v1.Service.CreateToken2022HoldingAccount:output_type -> protochain.solana.program.token.v1.CreateToken2022HoldingAccountResponse
+	10, // 32: protochain.solana.program.token.v1.Service.CreateSPLTokenHoldingAccount:output_type -> protochain.solana.program.token.v1.CreateSPLTokenHoldingAccountResponse
+	12, // 33: protochain.solana.program.token.v1.Service.Mint:output_type -> protochain.solana.program.token.v1.MintResponse
+	14, // 34: protochain.solana.program.token.v1.Service.FreezeTokenAccount:output_type -> protochain.solana.program.token.v1.FreezeTokenAccountResponse
+	16, // 35: protochain.solana.program.token.v1.Service.ThawTokenAccount:output_type -> protochain.solana.program.token.v1.ThawTokenAccountResponse
+	20, // 36: protochain.solana.program.token.v1.Service.BurnToken:output_type -> protochain.solana.program.token.v1.BurnTokenResponse
+	22, // 37: protochain.solana.program.token.v1.Service.TransferToken:output_type -> protochain.solana.program.token.v1.TransferTokenResponse
+	18, // 38: protochain.solana.program.token.v1.Service.CloseTokenAccount:output_type -> protochain.solana.program.token.v1.CloseTokenAccountResponse
+	28, // [28:39] is the sub-list for method output_type
+	17, // [17:28] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_protochain_solana_program_token_v1_service_proto_init() }
@@ -1609,7 +1766,7 @@ func file_protochain_solana_program_token_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_protochain_solana_program_token_v1_service_proto_rawDesc), len(file_protochain_solana_program_token_v1_service_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   21,
+			NumMessages:   23,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/lib/go/protochain/solana/program/token/v1/service_grpc.pb.go
+++ b/lib/go/protochain/solana/program/token/v1/service_grpc.pb.go
@@ -28,6 +28,7 @@ const (
 	Service_FreezeTokenAccount_FullMethodName            = "/protochain.solana.program.token.v1.Service/FreezeTokenAccount"
 	Service_ThawTokenAccount_FullMethodName              = "/protochain.solana.program.token.v1.Service/ThawTokenAccount"
 	Service_BurnToken_FullMethodName                     = "/protochain.solana.program.token.v1.Service/BurnToken"
+	Service_TransferToken_FullMethodName                 = "/protochain.solana.program.token.v1.Service/TransferToken"
 	Service_CloseTokenAccount_FullMethodName             = "/protochain.solana.program.token.v1.Service/CloseTokenAccount"
 )
 
@@ -132,6 +133,19 @@ type ServiceClient interface {
 	//
 	// NOTE: Multi-sig authorities are not yet supported.
 	BurnToken(ctx context.Context, in *BurnTokenRequest, opts ...grpc.CallOption) (*BurnTokenResponse, error)
+	// Transfers tokens between token accounts using the TransferChecked instruction.
+	//
+	// Token Program Agnostic — the service reads the mint account on-chain to
+	// determine the owning token program and the decimal precision.
+	//
+	// The Associated Token Accounts (ATAs) for both the source and destination
+	// owners are derived automatically from the mint and the owner addresses.
+	//
+	// The returned instruction must be signed by the source token account owner
+	// (or delegate, if one is set).
+	//
+	// NOTE: Multi-sig authorities are not yet supported.
+	TransferToken(ctx context.Context, in *TransferTokenRequest, opts ...grpc.CallOption) (*TransferTokenResponse, error)
 	// Closes a token account, transferring its remaining SOL rent to a
 	// destination address.
 	//
@@ -238,6 +252,16 @@ func (c *serviceClient) BurnToken(ctx context.Context, in *BurnTokenRequest, opt
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(BurnTokenResponse)
 	err := c.cc.Invoke(ctx, Service_BurnToken_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *serviceClient) TransferToken(ctx context.Context, in *TransferTokenRequest, opts ...grpc.CallOption) (*TransferTokenResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(TransferTokenResponse)
+	err := c.cc.Invoke(ctx, Service_TransferToken_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -355,6 +379,19 @@ type ServiceServer interface {
 	//
 	// NOTE: Multi-sig authorities are not yet supported.
 	BurnToken(context.Context, *BurnTokenRequest) (*BurnTokenResponse, error)
+	// Transfers tokens between token accounts using the TransferChecked instruction.
+	//
+	// Token Program Agnostic — the service reads the mint account on-chain to
+	// determine the owning token program and the decimal precision.
+	//
+	// The Associated Token Accounts (ATAs) for both the source and destination
+	// owners are derived automatically from the mint and the owner addresses.
+	//
+	// The returned instruction must be signed by the source token account owner
+	// (or delegate, if one is set).
+	//
+	// NOTE: Multi-sig authorities are not yet supported.
+	TransferToken(context.Context, *TransferTokenRequest) (*TransferTokenResponse, error)
 	// Closes a token account, transferring its remaining SOL rent to a
 	// destination address.
 	//
@@ -403,6 +440,9 @@ func (UnimplementedServiceServer) ThawTokenAccount(context.Context, *ThawTokenAc
 }
 func (UnimplementedServiceServer) BurnToken(context.Context, *BurnTokenRequest) (*BurnTokenResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method BurnToken not implemented")
+}
+func (UnimplementedServiceServer) TransferToken(context.Context, *TransferTokenRequest) (*TransferTokenResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method TransferToken not implemented")
 }
 func (UnimplementedServiceServer) CloseTokenAccount(context.Context, *CloseTokenAccountRequest) (*CloseTokenAccountResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method CloseTokenAccount not implemented")
@@ -590,6 +630,24 @@ func _Service_BurnToken_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Service_TransferToken_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(TransferTokenRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ServiceServer).TransferToken(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Service_TransferToken_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ServiceServer).TransferToken(ctx, req.(*TransferTokenRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Service_CloseTokenAccount_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(CloseTokenAccountRequest)
 	if err := dec(in); err != nil {
@@ -650,6 +708,10 @@ var Service_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "BurnToken",
 			Handler:    _Service_BurnToken_Handler,
+		},
+		{
+			MethodName: "TransferToken",
+			Handler:    _Service_TransferToken_Handler,
 		},
 		{
 			MethodName: "CloseTokenAccount",

--- a/lib/go/protochain/solana/program/token/v1/service_grpc_adaptor.passivgo.go
+++ b/lib/go/protochain/solana/program/token/v1/service_grpc_adaptor.passivgo.go
@@ -198,6 +198,23 @@ func (a *ServiceGRPCAdaptor) BurnToken(ctx context.Context, request *BurnTokenRe
 	return burnTokenResponse, nil
 }
 
+// TransferToken exposes the TransferToken method of the Service interface over gRPC
+func (a *ServiceGRPCAdaptor) TransferToken(ctx context.Context, request *TransferTokenRequest) (*TransferTokenResponse, error) {
+	ctx, span := a.tracer.Start(
+		ctx,
+		ServiceServiceProviderName+"GRPCAdaptor.TransferToken",
+	)
+	defer span.End()
+
+	// call the service interface implementation
+	transferTokenResponse, err := a.service.TransferToken(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	return transferTokenResponse, nil
+}
+
 // CloseTokenAccount exposes the CloseTokenAccount method of the Service interface over gRPC
 func (a *ServiceGRPCAdaptor) CloseTokenAccount(ctx context.Context, request *CloseTokenAccountRequest) (*CloseTokenAccountResponse, error) {
 	ctx, span := a.tracer.Start(

--- a/lib/go/protochain/solana/program/token/v1/service_interface.passivgo.go
+++ b/lib/go/protochain/solana/program/token/v1/service_interface.passivgo.go
@@ -112,6 +112,20 @@ type ServiceInterface interface {
 	// NOTE: Multi-sig authorities are not yet supported.
 	BurnToken(ctx context.Context, request *BurnTokenRequest) (*BurnTokenResponse, error)
 
+	// Transfers tokens between token accounts using the TransferChecked instruction.
+	//
+	// Token Program Agnostic — the service reads the mint account on-chain to
+	// determine the owning token program and the decimal precision.
+	//
+	// The Associated Token Accounts (ATAs) for both the source and destination
+	// owners are derived automatically from the mint and the owner addresses.
+	//
+	// The returned instruction must be signed by the source token account owner
+	// (or delegate, if one is set).
+	//
+	// NOTE: Multi-sig authorities are not yet supported.
+	TransferToken(ctx context.Context, request *TransferTokenRequest) (*TransferTokenResponse, error)
+
 	// Closes a token account, transferring its remaining SOL rent to a
 	// destination address.
 	//

--- a/lib/go/protochain/solana/program/token/v1/service_service.passivgo.go
+++ b/lib/go/protochain/solana/program/token/v1/service_service.passivgo.go
@@ -180,6 +180,14 @@ func (s *serviceService) BurnToken(ctx context.Context, request *BurnTokenReques
 	})
 }
 
+// TransferToken executes the TransferToken RPC method with automatic
+// client-side validation, timeout handling, distributed tracing, and authentication.
+func (s *serviceService) TransferToken(ctx context.Context, request *TransferTokenRequest) (*TransferTokenResponse, error) {
+	return common.Execute(s.Executor(), ctx, "TransferToken", request, func(ctx context.Context) (*TransferTokenResponse, error) {
+		return s.GrpcClient().TransferToken(ctx, request)
+	})
+}
+
 // CloseTokenAccount executes the CloseTokenAccount RPC method with automatic
 // client-side validation, timeout handling, distributed tracing, and authentication.
 func (s *serviceService) CloseTokenAccount(ctx context.Context, request *CloseTokenAccountRequest) (*CloseTokenAccountResponse, error) {

--- a/lib/proto/protochain/solana/program/token/v1/service.proto
+++ b/lib/proto/protochain/solana/program/token/v1/service.proto
@@ -116,6 +116,20 @@ service Service {
   // NOTE: Multi-sig authorities are not yet supported.
   rpc BurnToken(BurnTokenRequest) returns (BurnTokenResponse);
 
+  // Transfers tokens between token accounts using the TransferChecked instruction.
+  //
+  // Token Program Agnostic — the service reads the mint account on-chain to
+  // determine the owning token program and the decimal precision.
+  //
+  // The Associated Token Accounts (ATAs) for both the source and destination
+  // owners are derived automatically from the mint and the owner addresses.
+  //
+  // The returned instruction must be signed by the source token account owner
+  // (or delegate, if one is set).
+  //
+  // NOTE: Multi-sig authorities are not yet supported.
+  rpc TransferToken(TransferTokenRequest) returns (TransferTokenResponse);
+
   // Closes a token account, transferring its remaining SOL rent to a
   // destination address.
   //
@@ -428,5 +442,49 @@ message BurnTokenRequest {
 
 // Response containing the burn instruction.
 message BurnTokenResponse {
+  protochain.solana.transaction.v1.SolanaInstruction instruction = 1;
+}
+
+// Request to transfer tokens between token accounts.
+//
+// The service retrieves the mint account on-chain to resolve the decimal
+// precision and owning token program — so callers do not need to supply
+// those values.
+//
+// NOTE: Multi-sig authorities are not yet supported.
+message TransferTokenRequest {
+  // Public key of the token mint (Base58).
+  string mint_pub_key = 1;
+
+  // Public key of the **system account** (wallet) that owns the source
+  // token account.  The Associated Token Account (ATA) is derived
+  // automatically from this owner and the mint.
+  //
+  // Do NOT pass the ATA address itself — pass the owner's system account.
+  string source_owner_pub_key = 2;
+
+  // Public key of the **system account** (wallet) that owns the destination
+  // token account.  The Associated Token Account (ATA) is derived
+  // automatically from this owner and the mint.
+  //
+  // Do NOT pass the ATA address itself — pass the owner's system account.
+  string destination_owner_pub_key = 3;
+
+  // Human-readable token amount as a decimal string.
+  //
+  // Express the amount in whole-token units (e.g. "1.5" for one-and-a-half
+  // tokens).  The service converts this to the on-chain base-unit
+  // representation using the mint's decimal precision.
+  //
+  // Examples (assuming 6 decimals):
+  //   "1.0"     → 1 000 000 base units
+  //   "0.5"     → 500 000 base units
+  //   "1000"    → 1 000 000 000 base units
+  //   "0.000001"→ 1 base unit
+  string amount = 4;
+}
+
+// Response containing the transfer instruction.
+message TransferTokenResponse {
   protochain.solana.transaction.v1.SolanaInstruction instruction = 1;
 }

--- a/lib/rust/src/protochain.solana.program.token.v1.rs
+++ b/lib/rust/src/protochain.solana.program.token.v1.rs
@@ -749,5 +749,53 @@ pub struct BurnTokenResponse {
     #[prost(message, optional, tag="1")]
     pub instruction: ::core::option::Option<super::super::super::transaction::v1::SolanaInstruction>,
 }
+/// Request to transfer tokens between token accounts.
+///
+/// The service retrieves the mint account on-chain to resolve the decimal
+/// precision and owning token program — so callers do not need to supply
+/// those values.
+///
+/// NOTE: Multi-sig authorities are not yet supported.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransferTokenRequest {
+    /// Public key of the token mint (Base58).
+    #[prost(string, tag="1")]
+    pub mint_pub_key: ::prost::alloc::string::String,
+    /// Public key of the **system account** (wallet) that owns the source
+    /// token account.  The Associated Token Account (ATA) is derived
+    /// automatically from this owner and the mint.
+    ///
+    /// Do NOT pass the ATA address itself — pass the owner's system account.
+    #[prost(string, tag="2")]
+    pub source_owner_pub_key: ::prost::alloc::string::String,
+    /// Public key of the **system account** (wallet) that owns the destination
+    /// token account.  The Associated Token Account (ATA) is derived
+    /// automatically from this owner and the mint.
+    ///
+    /// Do NOT pass the ATA address itself — pass the owner's system account.
+    #[prost(string, tag="3")]
+    pub destination_owner_pub_key: ::prost::alloc::string::String,
+    /// Human-readable token amount as a decimal string.
+    ///
+    /// Express the amount in whole-token units (e.g. "1.5" for one-and-a-half
+    /// tokens).  The service converts this to the on-chain base-unit
+    /// representation using the mint's decimal precision.
+    ///
+    /// Examples (assuming 6 decimals):
+    ///    "1.0"     → 1 000 000 base units
+    ///    "0.5"     → 500 000 base units
+    ///    "1000"    → 1 000 000 000 base units
+    ///    "0.000001"→ 1 base unit
+    #[prost(string, tag="4")]
+    pub amount: ::prost::alloc::string::String,
+}
+/// Response containing the transfer instruction.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TransferTokenResponse {
+    #[prost(message, optional, tag="1")]
+    pub instruction: ::core::option::Option<super::super::super::transaction::v1::SolanaInstruction>,
+}
 include!("protochain.solana.program.token.v1.tonic.rs");
 // @@protoc_insertion_point(module)

--- a/lib/rust/src/protochain.solana.program.token.v1.tonic.rs
+++ b/lib/rust/src/protochain.solana.program.token.v1.tonic.rs
@@ -348,6 +348,36 @@ pub mod service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        pub async fn transfer_token(
+            &mut self,
+            request: impl tonic::IntoRequest<super::TransferTokenRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::TransferTokenResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/protochain.solana.program.token.v1.Service/TransferToken",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "protochain.solana.program.token.v1.Service",
+                        "TransferToken",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn close_token_account(
             &mut self,
             request: impl tonic::IntoRequest<super::CloseTokenAccountRequest>,
@@ -445,6 +475,13 @@ pub mod service_server {
             request: tonic::Request<super::BurnTokenRequest>,
         ) -> std::result::Result<
             tonic::Response<super::BurnTokenResponse>,
+            tonic::Status,
+        >;
+        async fn transfer_token(
+            &self,
+            request: tonic::Request<super::TransferTokenRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::TransferTokenResponse>,
             tonic::Status,
         >;
         async fn close_token_account(
@@ -929,6 +966,51 @@ pub mod service_server {
                     let inner = self.inner.clone();
                     let fut = async move {
                         let method = BurnTokenSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/protochain.solana.program.token.v1.Service/TransferToken" => {
+                    #[allow(non_camel_case_types)]
+                    struct TransferTokenSvc<T: Service>(pub Arc<T>);
+                    impl<
+                        T: Service,
+                    > tonic::server::UnaryService<super::TransferTokenRequest>
+                    for TransferTokenSvc<T> {
+                        type Response = super::TransferTokenResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::TransferTokenRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as Service>::transfer_token(&inner, request).await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let method = TransferTokenSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/tests/go/token_program_e2e_test.go
+++ b/tests/go/token_program_e2e_test.go
@@ -846,6 +846,183 @@ func (suite *TokenProgramE2ETestSuite) Test_05_Token_e2e() {
 	suite.T().Logf("   solana confirm %s --url http://localhost:8899", submittedMintTx.Signature)
 }
 
+// Test_06_TransferToken_e2e tests transferring tokens between two holding accounts
+func (suite *TokenProgramE2ETestSuite) Test_06_TransferToken_e2e() {
+	suite.T().Log("🎯 Testing Token Transfer between Holding Accounts")
+
+	// ────────── Setup: payer, mint, source wallet, destination wallet ──────────
+
+	// Generate and fund payer account
+	payKeyResp, err := suite.accountService.GenerateNewKeyPair(suite.ctx, &account_v1.GenerateNewKeyPairRequest{})
+	suite.Require().NoError(err, "Should generate payer keypair")
+
+	fundResp, err := suite.accountService.FundNative(suite.ctx, &account_v1.FundNativeRequest{
+		Address: payKeyResp.KeyPair.PublicKey,
+		Amount:  "5000000000", // 5 SOL
+	})
+	suite.Require().NoError(err, "Should fund payer account")
+	suite.monitorTransactionToCompletion(fundResp.GetSignature())
+	suite.T().Logf("  Funded payer account: %s", payKeyResp.KeyPair.PublicKey)
+
+	// Generate mint account keypair
+	mintKeyResp, err := suite.accountService.GenerateNewKeyPair(suite.ctx, &account_v1.GenerateNewKeyPairRequest{})
+	suite.Require().NoError(err, "Should generate mint keypair")
+
+	// Create Token-2022 mint (6 decimals, no extensions)
+	createMintResp, err := suite.tokenProgramService.CreateToken2022Mint(suite.ctx, &token_v1.CreateToken2022MintRequest{
+		PayerPubKey:           payKeyResp.KeyPair.PublicKey,
+		MintPubKey:            mintKeyResp.KeyPair.PublicKey,
+		MintAuthorityPubKey:   payKeyResp.KeyPair.PublicKey,
+		FreezeAuthorityPubKey: payKeyResp.KeyPair.PublicKey,
+		Decimals:              6,
+	})
+	suite.Require().NoError(err, "Should create Token-2022 mint")
+
+	// Submit mint creation transaction
+	suite.submitAndConfirm(
+		createMintResp.Instructions,
+		payKeyResp.KeyPair.PublicKey,
+		[]string{payKeyResp.KeyPair.PrivateKey, mintKeyResp.KeyPair.PrivateKey},
+	)
+	suite.T().Logf("  Mint created: %s", mintKeyResp.KeyPair.PublicKey)
+
+	// ────────── Create source holding account ──────────
+
+	sourceWalletResp, err := suite.accountService.GenerateNewKeyPair(suite.ctx, &account_v1.GenerateNewKeyPairRequest{})
+	suite.Require().NoError(err, "Should generate source wallet keypair")
+
+	sourceHoldingResp, err := suite.tokenProgramService.CreateToken2022HoldingAccount(suite.ctx, &token_v1.CreateToken2022HoldingAccountRequest{
+		PayerPubKey: payKeyResp.KeyPair.PublicKey,
+		MintPubKey:  mintKeyResp.KeyPair.PublicKey,
+		OwnerPubKey: sourceWalletResp.KeyPair.PublicKey,
+	})
+	suite.Require().NoError(err, "Should create source holding account")
+
+	suite.submitAndConfirm(
+		sourceHoldingResp.Instructions,
+		payKeyResp.KeyPair.PublicKey,
+		[]string{payKeyResp.KeyPair.PrivateKey},
+	)
+	suite.T().Logf("  Source holding account created for wallet: %s", sourceWalletResp.KeyPair.PublicKey)
+
+	// ────────── Create destination holding account ──────────
+
+	destWalletResp, err := suite.accountService.GenerateNewKeyPair(suite.ctx, &account_v1.GenerateNewKeyPairRequest{})
+	suite.Require().NoError(err, "Should generate destination wallet keypair")
+
+	destHoldingResp, err := suite.tokenProgramService.CreateToken2022HoldingAccount(suite.ctx, &token_v1.CreateToken2022HoldingAccountRequest{
+		PayerPubKey: payKeyResp.KeyPair.PublicKey,
+		MintPubKey:  mintKeyResp.KeyPair.PublicKey,
+		OwnerPubKey: destWalletResp.KeyPair.PublicKey,
+	})
+	suite.Require().NoError(err, "Should create destination holding account")
+
+	suite.submitAndConfirm(
+		destHoldingResp.Instructions,
+		payKeyResp.KeyPair.PublicKey,
+		[]string{payKeyResp.KeyPair.PrivateKey},
+	)
+	suite.T().Logf("  Destination holding account created for wallet: %s", destWalletResp.KeyPair.PublicKey)
+
+	// ────────── Mint tokens to source ──────────
+
+	mintInstr, err := suite.tokenProgramService.Mint(suite.ctx, &token_v1.MintRequest{
+		MintPubKey:             mintKeyResp.KeyPair.PublicKey,
+		DestinationOwnerPubKey: sourceWalletResp.KeyPair.PublicKey,
+		Amount:                 "10.0", // 10 tokens
+	})
+	suite.Require().NoError(err, "Should create mint instruction")
+
+	suite.submitAndConfirm(
+		[]*transaction_v1.SolanaInstruction{mintInstr.Instruction},
+		payKeyResp.KeyPair.PublicKey,
+		[]string{payKeyResp.KeyPair.PrivateKey}, // payer is mint authority
+	)
+	suite.T().Logf("  Minted 10.0 tokens to source wallet")
+
+	// ────────── Transfer tokens from source to destination ──────────
+
+	transferInstr, err := suite.tokenProgramService.TransferToken(suite.ctx, &token_v1.TransferTokenRequest{
+		MintPubKey:             mintKeyResp.KeyPair.PublicKey,
+		SourceOwnerPubKey:      sourceWalletResp.KeyPair.PublicKey,
+		DestinationOwnerPubKey: destWalletResp.KeyPair.PublicKey,
+		Amount:                 "3.5", // 3.5 tokens
+	})
+	suite.Require().NoError(err, "Should create transfer instruction")
+	suite.Require().NotNil(transferInstr.Instruction, "Transfer instruction should not be nil")
+
+	suite.submitAndConfirm(
+		[]*transaction_v1.SolanaInstruction{transferInstr.Instruction},
+		payKeyResp.KeyPair.PublicKey,
+		[]string{payKeyResp.KeyPair.PrivateKey, sourceWalletResp.KeyPair.PrivateKey}, // payer + source owner
+	)
+	suite.T().Logf("  Transferred 3.5 tokens from source to destination")
+
+	// ────────── Verify supply unchanged (transfer doesn't change supply) ──────────
+
+	var parsedMint *token_v1.ParseMintResponse
+	for attempt := 1; attempt <= 10; attempt++ {
+		parsedMint, err = suite.tokenProgramService.ParseMint(suite.ctx, &token_v1.ParseMintRequest{
+			AccountAddress: mintKeyResp.KeyPair.PublicKey,
+		})
+		suite.Require().NoError(err, "Should parse mint account (attempt %d)", attempt)
+
+		if parsedMint != nil && parsedMint.Mint != nil && parsedMint.Mint.Supply == "10000000" {
+			break
+		}
+		if attempt < 10 {
+			time.Sleep(200 * time.Millisecond)
+		}
+	}
+	suite.Assert().Equal("10000000", parsedMint.Mint.Supply,
+		"Mint supply should remain at 10_000_000 base units (10.0 tokens) after transfer")
+
+	suite.T().Logf("✅ Token transfer verified successfully:")
+	suite.T().Logf("   Mint: %s", mintKeyResp.KeyPair.PublicKey)
+	suite.T().Logf("   Source owner: %s", sourceWalletResp.KeyPair.PublicKey)
+	suite.T().Logf("   Dest owner: %s", destWalletResp.KeyPair.PublicKey)
+	suite.T().Logf("   Transferred: 3.5 tokens")
+}
+
+// submitAndConfirm is a test helper that compiles, signs, submits, and monitors
+// a transaction to completion. It fails the current test on any error.
+func (suite *TokenProgramE2ETestSuite) submitAndConfirm(
+	instructions []*transaction_v1.SolanaInstruction,
+	feePayer string,
+	privateKeys []string,
+) {
+	suite.T().Helper()
+
+	tx := &transaction_v1.Transaction{
+		Instructions: instructions,
+		State:        transaction_v1.TransactionState_TRANSACTION_STATE_DRAFT,
+	}
+
+	compiled, err := suite.transactionService.CompileTransaction(suite.ctx, &transaction_v1.CompileTransactionRequest{
+		Transaction: tx,
+		FeePayer:    feePayer,
+	})
+	suite.Require().NoError(err, "Should compile transaction")
+
+	signed, err := suite.transactionService.SignTransaction(suite.ctx, &transaction_v1.SignTransactionRequest{
+		Transaction: compiled.Transaction,
+		SigningMethod: &transaction_v1.SignTransactionRequest_PrivateKeys{
+			PrivateKeys: &transaction_v1.SignWithPrivateKeys{
+				PrivateKeys: privateKeys,
+			},
+		},
+	})
+	suite.Require().NoError(err, "Should sign transaction")
+
+	submitted, err := suite.transactionService.SubmitTransaction(suite.ctx, &transaction_v1.SubmitTransactionRequest{
+		Transaction: signed.Transaction,
+	})
+	suite.Require().NoError(err, "Should submit transaction")
+	suite.Require().NotEmpty(submitted.Signature, "Signature should not be empty (error: %s)", submitted.ErrorMessage)
+
+	suite.monitorTransactionToCompletion(submitted.Signature)
+}
+
 // monitorTransactionToCompletion monitors a transaction via websocket streaming
 // until it reaches CONFIRMED or FINALIZED status, failing the test on error/timeout/drop.
 func (suite *TokenProgramE2ETestSuite) monitorTransactionToCompletion(signature string) {


### PR DESCRIPTION
Adds a TransferToken RPC that transfers tokens between holding accounts using the TransferChecked instruction.                                                                                        
                                                                                                                                                                                                       
 The service resolves the token program and decimal precision from the on-chain mint account, derives source and destination ATAs from the provided owner public keys, and accepts a human-readable    
 decimal amount string (e.g. "3.5").                                                                                                                                                                   
                                                                                                                                                                                                       
 - Proto: new TransferToken RPC, TransferTokenRequest/TransferTokenResponse messages                                                                                                                   
 - Rust: transfer.rs handler with input validation, on-chain mint lookup, ATA derivation                                                                                                               
 - Works with both SPL Token and Token-2022 mints                                                                                                                                                      
 - E2E test covering mint creation → holding account setup → mint tokens → transfer → supply verification